### PR TITLE
Fix missing names for materials

### DIFF
--- a/GLTF/src/GLTFMaterial.cpp
+++ b/GLTF/src/GLTFMaterial.cpp
@@ -237,6 +237,7 @@ void GLTF::MaterialPBR::writeJSON(void* writer, GLTF::Options* options) {
 			jsonWriter->EndObject();
 		}
 	}
+	GLTF::Object::writeJSON(writer, options);
 }
 
 void GLTF::MaterialCommon::Light::writeJSON(void* writer, GLTF::Options* options) {


### PR DESCRIPTION
Literally a one line fix. This was creating an issue for a material replacement system for a pipeline. Figured I'd point out this simple fix.