### PR TITLE
Make element ordering deterministic

### DIFF
--- a/GLTF/include/GLTFAsset.h
+++ b/GLTF/include/GLTFAsset.h
@@ -30,17 +30,17 @@ namespace GLTF {
 
 		Asset();
 		GLTF::Scene* getDefaultScene();
-		std::set<GLTF::Accessor*> getAllAccessors();
-		std::set<GLTF::Node*> getAllNodes();
-		std::set<GLTF::Mesh*> getAllMeshes();
-		std::set<GLTF::Primitive*> getAllPrimitives();
-		std::set<GLTF::Skin*> getAllSkins();
-		std::set<GLTF::Material*> getAllMaterials();
-		std::set<GLTF::Technique*> getAllTechniques();
-		std::set<GLTF::Program*> getAllPrograms();
-		std::set<GLTF::Shader*> getAllShaders();
-		std::set<GLTF::Texture*> getAllTextures();
-		std::set<GLTF::Image*> getAllImages();
+		std::vector<GLTF::Accessor*> getAllAccessors();
+		std::vector<GLTF::Node*> getAllNodes();
+		std::vector<GLTF::Mesh*> getAllMeshes();
+		std::vector<GLTF::Primitive*> getAllPrimitives();
+		std::vector<GLTF::Skin*> getAllSkins();
+		std::vector<GLTF::Material*> getAllMaterials();
+		std::vector<GLTF::Technique*> getAllTechniques();
+		std::vector<GLTF::Program*> getAllPrograms();
+		std::vector<GLTF::Shader*> getAllShaders();
+		std::vector<GLTF::Texture*> getAllTextures();
+		std::vector<GLTF::Image*> getAllImages();
 		void removeUnusedSemantics();
 		void removeUnusedNodes(GLTF::Options* options);
 		GLTF::Buffer* packAccessors();

--- a/GLTF/src/GLTFAccessor.cpp
+++ b/GLTF/src/GLTFAccessor.cpp
@@ -1,6 +1,7 @@
 #include <algorithm>
 #include <limits>
 #include <cstring>
+#include <set>
 #include <stdlib.h>
 
 #include "GLTFAccessor.h"

--- a/GLTF/src/GLTFAsset.cpp
+++ b/GLTF/src/GLTFAsset.cpp
@@ -45,46 +45,63 @@ GLTF::Scene* GLTF::Asset::getDefaultScene() {
 	return scene;
 }
 
-std::set<GLTF::Accessor*> GLTF::Asset::getAllAccessors() {
-	std::set<GLTF::Accessor*> accessors;
+std::vector<GLTF::Accessor*> GLTF::Asset::getAllAccessors() {
+	std::set<GLTF::Accessor*> uniqueAccessors;
+	std::vector<GLTF::Accessor*> accessors;
 	for (GLTF::Skin* skin : getAllSkins()) {
 		GLTF::Accessor* inverseBindMatrices = skin->inverseBindMatrices;
 		if (inverseBindMatrices != NULL) {
-			accessors.insert(inverseBindMatrices);
+			if (uniqueAccessors.find(inverseBindMatrices) == uniqueAccessors.end()) {
+				accessors.push_back(inverseBindMatrices);
+				uniqueAccessors.insert(inverseBindMatrices);
+			}
 		}
 	}
 
 	for (GLTF::Primitive* primitive : getAllPrimitives()) {
 		for (const auto attribute : primitive->attributes) {
-			accessors.insert(attribute.second);
+			if (uniqueAccessors.find(attribute.second) == uniqueAccessors.end()) {
+				accessors.push_back(attribute.second);
+				uniqueAccessors.insert(attribute.second);
+			}
 		}
 		GLTF::Accessor* indicesAccessor = primitive->indices;
 		if (indicesAccessor != NULL) {
-			accessors.insert(indicesAccessor);
+			if (uniqueAccessors.find(indicesAccessor) == uniqueAccessors.end()) {
+				accessors.push_back(indicesAccessor);
+				uniqueAccessors.insert(indicesAccessor);
+			}
 		}
 	}
 
 	for (GLTF::Animation* animation : animations) {
 		for (GLTF::Animation::Channel* channel : animation->channels) {
 			GLTF::Animation::Sampler* sampler = channel->sampler;
-			accessors.insert(sampler->input);
-			accessors.insert(sampler->output);
+			if (uniqueAccessors.find(sampler->input) == uniqueAccessors.end()) {
+				accessors.push_back(sampler->input);
+				uniqueAccessors.insert(sampler->input);
+			}
+			if (uniqueAccessors.find(sampler->output) == uniqueAccessors.end()) {
+				accessors.push_back(sampler->output);
+				uniqueAccessors.insert(sampler->input);
+			}
 		}
 	}
 	return accessors;
 }
 
-std::set<GLTF::Node*> GLTF::Asset::getAllNodes() {
+std::vector<GLTF::Node*> GLTF::Asset::getAllNodes() {
 	std::vector<GLTF::Node*> nodeStack;
-	std::set<GLTF::Node*> nodes;
+	std::vector<GLTF::Node*> nodes;
+	std::set<GLTF::Node*> uniqueNodes;
 	for (GLTF::Node* node : getDefaultScene()->nodes) {
 		nodeStack.push_back(node);
 	}
 	while (nodeStack.size() > 0) {
 		GLTF::Node* node = nodeStack.back();
-		std::set<GLTF::Node*>::iterator it = std::find(nodes.begin(), nodes.end(), node);
-		if (it == nodes.end()) {
-			nodes.insert(node);
+		if (uniqueNodes.find(node) == uniqueNodes.end()) {
+			nodes.push_back(node);
+			uniqueNodes.insert(node);
 		}
 		nodeStack.pop_back();
 		for (GLTF::Node* child : node->children) {
@@ -104,136 +121,205 @@ std::set<GLTF::Node*> GLTF::Asset::getAllNodes() {
 	return nodes;
 }
 
-std::set<GLTF::Mesh*> GLTF::Asset::getAllMeshes() {
-	std::set<GLTF::Mesh*> meshes;
+std::vector<GLTF::Mesh*> GLTF::Asset::getAllMeshes() {
+	std::vector<GLTF::Mesh*> meshes;
+	std::set<GLTF::Mesh*> uniqueMeshes;
 	for (GLTF::Node* node : getAllNodes()) {
 		if (node->mesh != NULL) {
-			meshes.insert(node->mesh);
+			if (uniqueMeshes.find(node->mesh) == uniqueMeshes.end()) {
+				meshes.push_back(node->mesh);
+				uniqueMeshes.insert(node->mesh);
+			}
 		}
 	}
 	return meshes;
 }
 
-std::set<GLTF::Primitive*> GLTF::Asset::getAllPrimitives() {
-	std::set<GLTF::Primitive*> primitives;
+std::vector<GLTF::Primitive*> GLTF::Asset::getAllPrimitives() {
+	std::vector<GLTF::Primitive*> primitives;
+	std::set<GLTF::Primitive*> uniquePrimitives;
 	for (GLTF::Mesh* mesh : getAllMeshes()) {
 		for (GLTF::Primitive* primitive : mesh->primitives) {
-			primitives.insert(primitive);
+			if (uniquePrimitives.find(primitive) == uniquePrimitives.end()) {
+				primitives.push_back(primitive);
+				uniquePrimitives.insert(primitive);
+			}
 		}
 	}
 	return primitives;
 }
 
-std::set<GLTF::Skin*> GLTF::Asset::getAllSkins() {
-	std::set<GLTF::Skin*> skins;
+std::vector<GLTF::Skin*> GLTF::Asset::getAllSkins() {
+	std::vector<GLTF::Skin*> skins;
+	std::set<GLTF::Skin*> uniqueSkins;
 	for (GLTF::Node* node : getAllNodes()) {
 		GLTF::Skin* skin = node->skin;
 		if (skin != NULL) {
-			skins.insert(skin);
+			if (uniqueSkins.find(skin) == uniqueSkins.end()) {
+				skins.push_back(skin);
+				uniqueSkins.insert(skin);
+			}
 		}
 	}
 	return skins;
 }
 
-std::set<GLTF::Material*> GLTF::Asset::getAllMaterials() {
-	std::set<GLTF::Material*> materials;
+std::vector<GLTF::Material*> GLTF::Asset::getAllMaterials() {
+	std::vector<GLTF::Material*> materials;
+	std::set<GLTF::Material*> uniqueMaterials;
 	for (GLTF::Primitive* primitive : getAllPrimitives()) {
 		GLTF::Material* material = primitive->material;
 		if (material != NULL) {
-			materials.insert(material);
+			if (uniqueMaterials.find(material) == uniqueMaterials.end()) {
+				materials.push_back(material);
+				uniqueMaterials.insert(material);
+			}
 		}
 	}
 	return materials;
 }
 
-std::set<GLTF::Technique*> GLTF::Asset::getAllTechniques() {
-	std::set<GLTF::Technique*> techniques;
+std::vector<GLTF::Technique*> GLTF::Asset::getAllTechniques() {
+	std::vector<GLTF::Technique*> techniques;
+	std::set<GLTF::Technique*> uniqueTechniques;
 	for (GLTF::Material* material : getAllMaterials()) {
 		GLTF::Technique* technique = material->technique;
 		if (technique != NULL) {
-			techniques.insert(technique);
+			if (uniqueTechniques.find(technique) == uniqueTechniques.end()) {
+				techniques.push_back(technique);
+				uniqueTechniques.insert(technique);
+			}
 		}
 	}
 	return techniques;
 }
 
-std::set<GLTF::Program*> GLTF::Asset::getAllPrograms() {
-	std::set<GLTF::Program*> programs;
+std::vector<GLTF::Program*> GLTF::Asset::getAllPrograms() {
+	std::vector<GLTF::Program*> programs;
+	std::set<GLTF::Program*> uniquePrograms;
 	for (GLTF::Technique* technique : getAllTechniques()) {
 		GLTF::Program* program = technique->program;
 		if (program != NULL) {
-			programs.insert(program);
+			if (uniquePrograms.find(program) == uniquePrograms.end()) {
+				programs.push_back(program);
+				uniquePrograms.insert(program);
+			}
 		}
 	}
 	return programs;
 }
-std::set<GLTF::Shader*> GLTF::Asset::getAllShaders() {
-	std::set<GLTF::Shader*> shaders;
+std::vector<GLTF::Shader*> GLTF::Asset::getAllShaders() {
+	std::vector<GLTF::Shader*> shaders;
+	std::set<GLTF::Shader*> uniqueShaders;
 	for (GLTF::Program* program : getAllPrograms()) {
 		GLTF::Shader* vertexShader = program->vertexShader;
 		if (vertexShader != NULL) {
-			shaders.insert(vertexShader);
+			if (uniqueShaders.find(vertexShader) == uniqueShaders.end()) {
+				shaders.push_back(vertexShader);
+				uniqueShaders.insert(vertexShader);
+			}
 		}
 		GLTF::Shader* fragmentShader = program->fragmentShader;
 		if (fragmentShader != NULL) {
-			shaders.insert(fragmentShader);
+			if (uniqueShaders.find(vertexShader) == uniqueShaders.end()) {
+				shaders.push_back(fragmentShader);
+				uniqueShaders.insert(fragmentShader);
+			}
 		}
 	}
 	return shaders;
 }
 
-std::set<GLTF::Texture*> GLTF::Asset::getAllTextures() {
-	std::set<GLTF::Texture*> textures;
+std::vector<GLTF::Texture*> GLTF::Asset::getAllTextures() {
+	std::vector<GLTF::Texture*> textures;
+	std::set<GLTF::Texture*> uniqueTextures;
 	for (GLTF::Material* material : getAllMaterials()) {
 		if (material->type == GLTF::Material::MATERIAL || material->type == GLTF::Material::MATERIAL_COMMON) {
 			GLTF::Material::Values* values = material->values;
 			if (values->ambientTexture != NULL) {
-				textures.insert(values->ambientTexture);
+				if (uniqueTextures.find(values->ambientTexture) == uniqueTextures.end()) {
+					textures.push_back(values->ambientTexture);
+					uniqueTextures.insert(values->ambientTexture);
+				}
 			}
 			if (values->diffuseTexture != NULL) {
-				textures.insert(values->diffuseTexture);
+				if (uniqueTextures.find(values->diffuseTexture) == uniqueTextures.end()) {
+					textures.push_back(values->diffuseTexture);
+					uniqueTextures.insert(values->diffuseTexture);
+				}
 			}
 			if (values->emissionTexture != NULL) {
-				textures.insert(values->emissionTexture);
+				if (uniqueTextures.find(values->emissionTexture) == uniqueTextures.end()) {
+					textures.push_back(values->emissionTexture);
+					uniqueTextures.insert(values->emissionTexture);
+				}
 			}
 			if (values->specularTexture != NULL) {
-				textures.insert(values->specularTexture);
+				if (uniqueTextures.find(values->specularTexture) == uniqueTextures.end()) {
+					textures.push_back(values->specularTexture);
+					uniqueTextures.insert(values->specularTexture);
+				}
 			}
 		}
 		else if (material->type == GLTF::Material::PBR_METALLIC_ROUGHNESS) {
 			GLTF::MaterialPBR* materialPBR = (GLTF::MaterialPBR*)material;
 			if (materialPBR->metallicRoughness->baseColorTexture != NULL) {
-				textures.insert(materialPBR->metallicRoughness->baseColorTexture->texture);
+				if (uniqueTextures.find(materialPBR->metallicRoughness->baseColorTexture->texture) == uniqueTextures.end()) {
+					textures.push_back(materialPBR->metallicRoughness->baseColorTexture->texture);
+					uniqueTextures.insert(materialPBR->metallicRoughness->baseColorTexture->texture);
+				}
 			}
 			if (materialPBR->metallicRoughness->metallicRoughnessTexture != NULL) {
-				textures.insert(materialPBR->metallicRoughness->metallicRoughnessTexture->texture);
+				if (uniqueTextures.find(materialPBR->metallicRoughness->metallicRoughnessTexture->texture) == uniqueTextures.end()) {
+					textures.push_back(materialPBR->metallicRoughness->metallicRoughnessTexture->texture);
+					uniqueTextures.insert(materialPBR->metallicRoughness->metallicRoughnessTexture->texture);
+				}
 			}
 			if (materialPBR->emissiveTexture != NULL) {
-				textures.insert(materialPBR->emissiveTexture->texture);
+				if (uniqueTextures.find(materialPBR->emissiveTexture->texture) == uniqueTextures.end()) {
+					textures.push_back(materialPBR->emissiveTexture->texture);
+					uniqueTextures.insert(materialPBR->emissiveTexture->texture);
+				}
 			}
 			if (materialPBR->normalTexture != NULL) {
-				textures.insert(materialPBR->normalTexture->texture);
+				if (uniqueTextures.find(materialPBR->normalTexture->texture) == uniqueTextures.end()) {
+					textures.push_back(materialPBR->normalTexture->texture);
+					uniqueTextures.insert(materialPBR->normalTexture->texture);
+				}
 			}
 			if (materialPBR->occlusionTexture != NULL) {
-				textures.insert(materialPBR->occlusionTexture->texture);
+				if (uniqueTextures.find(materialPBR->occlusionTexture->texture) == uniqueTextures.end()) {
+					textures.push_back(materialPBR->occlusionTexture->texture);
+					uniqueTextures.insert(materialPBR->occlusionTexture->texture);
+				}
 			}
 			if (materialPBR->specularGlossiness->diffuseTexture != NULL) {
-				textures.insert(materialPBR->specularGlossiness->diffuseTexture->texture);
+				if (uniqueTextures.find(materialPBR->specularGlossiness->diffuseTexture->texture) == uniqueTextures.end()) {
+					textures.push_back(materialPBR->specularGlossiness->diffuseTexture->texture);
+					uniqueTextures.insert(materialPBR->specularGlossiness->diffuseTexture->texture);
+				}
 			}
 			if (materialPBR->specularGlossiness->specularGlossinessTexture != NULL) {
-				textures.insert(materialPBR->specularGlossiness->specularGlossinessTexture->texture);
+				if (uniqueTextures.find(materialPBR->specularGlossiness->specularGlossinessTexture->texture) == uniqueTextures.end()) {
+					textures.push_back(materialPBR->specularGlossiness->specularGlossinessTexture->texture);
+					uniqueTextures.insert(materialPBR->specularGlossiness->specularGlossinessTexture->texture);
+				}
 			}
 		}
 	}
 	return textures;
 }
 
-std::set<GLTF::Image*> GLTF::Asset::getAllImages() {
-	std::set<GLTF::Image*> images;
+std::vector<GLTF::Image*> GLTF::Asset::getAllImages() {
+	std::vector<GLTF::Image*> images;
+	std::set<GLTF::Image*> uniqueImages;
 	for (GLTF::Texture* texture : getAllTextures()) {
 		GLTF::Image* image = texture->source;
 		if (image != NULL) {
-			images.insert(image);
+			if (uniqueImages.find(image) == uniqueImages.end()) {
+				images.push_back(image);
+				uniqueImages.insert(image);
+			}
 		}
 	}
 	return images;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -156,7 +156,7 @@ int main(int argc, const char **argv) {
 		// Create image bufferViews for binary glTF
 		if (options->binary && options->embeddedTextures) {
 			size_t imageBufferLength = 0;
-			std::set<GLTF::Image*> images = asset->getAllImages();
+			std::vector<GLTF::Image*> images = asset->getAllImages();
 			for (GLTF::Image* image : images) {
 				imageBufferLength += image->byteLength;
 			}


### PR DESCRIPTION
For #49. Element aggregators return vectors instead of sets. This is confirmed to produce the same element ordering between runs.