### PR TITLE
Added precompiled option to accelerate appveyor build

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -21,10 +21,6 @@ configuration:
 - Debug
 - Release
 
-cache:
-- cmake-build/dependencies -> appveyor.yml, .gitmodules
-- cmake-build/GLTF/dependencies -> appveyor.yml, .gitmodules
-
 install:
 - powershell -Command "(gc .gitmodules) -replace 'git@github.com:', 'https://github.com/' | Out-File .gitmodules" -encoding UTF8
 - git submodule update --init --recursive

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -32,8 +32,10 @@ install:
 before_build:
 - if not exist cmake-build mkdir cmake-build
 - cd cmake-build
-- IF "%PLATFORM%"=="Win32" cmake -G "Visual Studio 14 2015" .. -Dtest=ON
-- IF "%PLATFORM%"=="x64" cmake -G "Visual Studio 14 2015 Win64" .. -Dtest=ON
+- if "%PLATFORM%"=="Win32" if "%CONFIGURATION%"=="Debug" cmake -G "Visual Studio 14 2015" .. -Dtest=ON -Dprecompiled=DEBUG,X86
+- if "%PLATFORM%"=="x64" if "%CONFIGURATION%"=="Debug" cmake -G "Visual Studio 14 2015 Win64" .. -Dtest=ON -Dprecompiled=DEBUG,X64
+- if "%PLATFORM%"=="Win32" if "%CONFIGURATION%"=="Release" cmake -G "Visual Studio 14 2015" .. -Dtest=ON -Dprecompiled=RELEASE,X86
+- if "%PLATFORM%"=="x64" if "%CONFIGURATION%"=="Release" cmake -G "Visual Studio 14 2015 Win64" .. -Dtest=ON -Dprecompiled=RELEASE,X64
 
 build:
   parallel: true

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,10 @@
 cmake_minimum_required (VERSION 3.1.0)
 
 set(PROJECT_NAME COLLADA2GLTF)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_EXTENSIONS OFF)
+include(ExternalProject)
 
 project(${PROJECT_NAME})
 if(MSVC)
@@ -10,7 +14,7 @@ if(MSVC)
   set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} /MT")
   add_definitions(-D_CRT_SECURE_NO_WARNINGS)
 elseif(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
-  add_compile_options(-std=c++11 -lstdc++fs)
+  add_compile_options(-lstdc++fs)
 endif()
 
 # cmake -Dtest=ON to build with tests
@@ -27,12 +31,78 @@ set(test OFF)
 # RapidJSON
 include_directories(GLTF/dependencies/rapidjson/include)
 
+# Pre-compiled
+if(precompiled MATCHES "X86")
+  if(precompiled MATCHES "DEBUG")
+    if(MSVC)
+      ExternalProject_Add(
+        precompiled
+        URL https://github.com/KhronosGroup/COLLADA2GLTF/releases/download/dependencies/dependencies-windows-Debug-Win32.zip
+        CONFIGURE_COMMAND ""
+        BUILD_COMMAND ""
+        INSTALL_COMMAND ""
+      )
+      set(PRECOMPILED_DIR ${CMAKE_CURRENT_BINARY_DIR}/precompiled-prefix/src/precompiled)
+    endif()
+  elseif(precompiled MATCHES "RELEASE")
+    if(MSVC)
+      ExternalProject_Add(
+        precompiled
+        URL https://github.com/KhronosGroup/COLLADA2GLTF/releases/download/dependencies/dependencies-windows-Release-Win32.zip
+        CONFIGURE_COMMAND ""
+        BUILD_COMMAND ""
+        INSTALL_COMMAND ""
+      )
+      set(PRECOMPILED_DIR ${CMAKE_CURRENT_BINARY_DIR}/precompiled-prefix/src/precompiled)
+    endif()
+  endif()
+elseif(precompiled MATCHES "X64")
+  if(precompiled MATCHES "DEBUG")
+    if(MSVC)
+      ExternalProject_Add(
+        precompiled
+        URL https://github.com/KhronosGroup/COLLADA2GLTF/releases/download/dependencies/dependencies-windows-Debug-x64.zip
+        CONFIGURE_COMMAND ""
+        BUILD_COMMAND ""
+        INSTALL_COMMAND ""
+      )
+      set(PRECOMPILED_DIR ${CMAKE_CURRENT_BINARY_DIR}/precompiled-prefix/src/precompiled)
+    endif()
+  elseif(precompiled MATCHES "RELEASE")
+    if(MSVC)
+      ExternalProject_Add(
+        precompiled
+        URL https://github.com/KhronosGroup/COLLADA2GLTF/releases/download/dependencies/dependencies-windows-Release-x64.zip
+        CONFIGURE_COMMAND ""
+        BUILD_COMMAND ""
+        INSTALL_COMMAND ""
+      )
+      set(PRECOMPILED_DIR ${CMAKE_CURRENT_BINARY_DIR}/precompiled-prefix/src/precompiled)
+    endif()
+  endif()
+endif()
+
+if(PRECOMPILED_DIR)
+  set(OpenCOLLADA
+    ${PRECOMPILED_DIR}/COLLADABaseUtils.lib
+    ${PRECOMPILED_DIR}/COLLADAFramework.lib
+    ${PRECOMPILED_DIR}/COLLADASaxFrameworkLoader.lib
+    ${PRECOMPILED_DIR}/expat.lib
+    ${PRECOMPILED_DIR}/GeneratedSaxParser.lib
+    ${PRECOMPILED_DIR}/LibXML.lib
+    ${PRECOMPILED_DIR}/MathMLSolver.lib
+    ${PRECOMPILED_DIR}/pcre.lib)
+endif()
+
 # COLLADASaxFrameworkLoader/BaseUtils/Framework, GeneratedSaxParser
 include_directories(dependencies/OpenCOLLADA/OpenCOLLADA/COLLADASaxFrameworkLoader/include)
 include_directories(dependencies/OpenCOLLADA/OpenCOLLADA/COLLADABaseUtils/include)
 include_directories(dependencies/OpenCOLLADA/OpenCOLLADA/COLLADAFramework/include)
 include_directories(dependencies/OpenCOLLADA/OpenCOLLADA/GeneratedSaxParser/include)
-add_subdirectory(dependencies/OpenCOLLADA/modules/COLLADASaxFrameworkLoader)
+if(NOT OpenCOLLADA)
+  add_subdirectory(dependencies/OpenCOLLADA/modules/COLLADASaxFrameworkLoader)
+  set(OpenCOLLADA COLLADASaxFrameworkLoader)
+endif()
 
 # COLLADA2GLTF
 include_directories(include)
@@ -40,9 +110,9 @@ file(GLOB LIB_HEADERS "include/*.h")
 set(LIB_SOURCES src/COLLADA2GLTFWriter.cpp src/COLLADA2GLTFExtrasHandler.cpp)
 add_library(${PROJECT_NAME} ${LIB_HEADERS} ${LIB_SOURCES})
 if(MSVC)
-   target_link_libraries(${PROJECT_NAME} GLTF COLLADASaxFrameworkLoader)
+   target_link_libraries(${PROJECT_NAME} GLTF ${OpenCOLLADA})
 elseif(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
-   target_link_libraries(${PROJECT_NAME} GLTF COLLADASaxFrameworkLoader stdc++fs)
+   target_link_libraries(${PROJECT_NAME} GLTF ${OpenCOLLADA} stdc++fs)
 endif()
 
 # ahoy
@@ -70,7 +140,7 @@ if(TEST_ENABLED)
   file(GLOB TEST_SOURCES "test/src/*.cpp")
 
   add_executable(${PROJECT_NAME}-test ${TEST_HEADERS} ${TEST_SOURCES})
-  target_link_libraries(${PROJECT_NAME}-test  ${PROJECT_NAME} GLTF gtest)
+  target_link_libraries(${PROJECT_NAME}-test ${PROJECT_NAME} GLTF gtest)
 
   add_test(COLLADA2GLTFWriterTest ${PROJECT_NAME}-test)
 endif()


### PR DESCRIPTION
Closes #54.

Cuts Appveyor build time from 26 minutes to ~8. 

This is only for Appveyor (Windows builds), and only on 2.0. I do not currently plan to try to hack this into the 1.0 cmake build.

This will also get added to the Travis build likely when I'm adding Mac OS build support.