### PR TITLE
CMake cleanup

### DIFF
--- a/GLTF/CMakeLists.txt
+++ b/GLTF/CMakeLists.txt
@@ -1,10 +1,14 @@
 cmake_minimum_required(VERSION 3.1.0)
+set_property(GLOBAL PROPERTY USE_FOLDERS TRUE)
 
 set(PROJECT_NAME GLTF)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 project(${PROJECT_NAME})
 if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
-  add_compile_options(-std=c++11 -lstdc++fs)
+  add_compile_options(-lstdc++fs)
 endif()
 
 # cmake -Dtest=ON to build with tests
@@ -16,6 +20,10 @@ include_directories(dependencies/rapidjson/include)
 # Draco
 include_directories(dependencies/draco/src)
 add_subdirectory(dependencies/draco)
+get_property(draco_targets DIRECTORY dependencies/draco PROPERTY BUILDSYSTEM_TARGETS)
+foreach(draco_target IN LISTS draco_targets)
+	set_target_properties(${draco_target} PROPERTIES FOLDER "draco")
+endforeach()
 
 # gltf
 include_directories(include)


### PR DESCRIPTION
Removes redundant c++11 flag and properly sets the standard in GLTF cmakelists. 

There are quite a few draco targets. This puts them in a folder so they don't clutter up the Visual Studio solution for Windows developers.