### PR TITLE
Removed byteOffset in accessors when there is no bufferView

### DIFF
--- a/GLTF/src/GLTFAccessor.cpp
+++ b/GLTF/src/GLTFAccessor.cpp
@@ -250,9 +250,9 @@ void GLTF::Accessor::writeJSON(void* writer, GLTF::Options* options) {
 	if (this->bufferView) {
 		jsonWriter->Key("bufferView");
 		jsonWriter->Int(this->bufferView->id);
+		jsonWriter->Key("byteOffset");
+		jsonWriter->Int(this->byteOffset);
 	}
-	jsonWriter->Key("byteOffset");
-	jsonWriter->Int(this->byteOffset);
 	jsonWriter->Key("componentType");
 	jsonWriter->Int((int)this->componentType);
 	jsonWriter->Key("count");


### PR DESCRIPTION
According to the glTF-Validator, when there is no `bufferView` in `accessor`, the `byteOffset` should be omitted as well.