### PR TITLE
fix Material names

### DIFF
--- a/GLTF/include/GLTFMaterial.h
+++ b/GLTF/include/GLTFMaterial.h
@@ -38,6 +38,7 @@ namespace GLTF {
 		Values* values = NULL;
 
 		Material();
+		GLTF::Material * getInstancedEffect(std::string name);
 		bool hasTexture();
 		virtual void writeJSON(void* writer, GLTF::Options* options);
 	};

--- a/GLTF/src/GLTFMaterial.cpp
+++ b/GLTF/src/GLTFMaterial.cpp
@@ -13,6 +13,13 @@ bool GLTF::Material::hasTexture() {
 	return this->values->diffuseTexture != NULL;
 }
 
+GLTF::Material * GLTF::Material::getInstancedEffect(std::string name) {
+	// TODO - apply Material parameters to the effect, not just the name
+	GLTF::Material *instancedEffect = new GLTF::Material(*this);
+	instancedEffect -> name = name;
+	return instancedEffect;
+}
+
 void GLTF::Material::Values::writeJSON(void* writer, GLTF::Options* options) {
 	rapidjson::Writer<rapidjson::StringBuffer>* jsonWriter = (rapidjson::Writer<rapidjson::StringBuffer>*)writer;
 	if (ambient != NULL || ambientTexture != NULL) {

--- a/include/COLLADA2GLTFWriter.h
+++ b/include/COLLADA2GLTFWriter.h
@@ -19,6 +19,7 @@ namespace COLLADA2GLTF {
 		COLLADA2GLTF::ExtrasHandler* _extrasHandler;
 		GLTF::Node* _rootNode = NULL;
 		std::map<COLLADAFW::UniqueId, COLLADAFW::UniqueId> _materialEffects;
+		std::map<COLLADAFW::UniqueId, std::string > _materialName;
 		std::map<COLLADAFW::UniqueId, GLTF::Material*> _effectInstances;
 		std::map<COLLADAFW::UniqueId, GLTF::Camera*> _cameraInstances;
 		std::map<COLLADAFW::UniqueId, GLTF::Mesh*> _meshInstances;

--- a/src/COLLADA2GLTFWriter.cpp
+++ b/src/COLLADA2GLTFWriter.cpp
@@ -257,7 +257,9 @@ bool COLLADA2GLTF::Writer::writeNodeToGroup(std::vector<GLTF::Node*>* group, con
 				GLTF::Primitive* primitive = skinnedMesh->primitives[j];
 				COLLADAFW::UniqueId materialId = materialBinding.getReferencedMaterial();
 				COLLADAFW::UniqueId effectId = this->_materialEffects[materialId];
-				GLTF::Material* material = _effectInstances[effectId];
+
+				GLTF::Material* material = _effectInstances[effectId]->getInstancedEffect(this->_materialName[materialId]);
+
 				if (material->type == GLTF::Material::Type::MATERIAL_COMMON) {
 					GLTF::MaterialCommon* materialCommon = (GLTF::MaterialCommon*)material;
 					materialCommon->jointCount = _skinJointNodes[uniqueId].size();
@@ -319,7 +321,9 @@ bool COLLADA2GLTF::Writer::writeNodeToGroup(std::vector<GLTF::Node*>* group, con
 					COLLADAFW::MaterialBinding materialBinding = materialBindings[j];
 					COLLADAFW::UniqueId materialId = materialBinding.getReferencedMaterial();
 					COLLADAFW::UniqueId effectId = this->_materialEffects[materialId];
-					GLTF::Material* material = _effectInstances[effectId];
+
+					GLTF::Material* material = _effectInstances[effectId]->getInstancedEffect(this->_materialName[materialId]);
+
 					for (GLTF::Primitive* primitive : primitiveMaterialMapping[materialBinding.getMaterialId()]) {
 						if (primitive->material != NULL && primitive->material != material) {
 							// This mesh primitive has a different material from a previous instance, clone the mesh and primitives
@@ -816,7 +820,11 @@ bool COLLADA2GLTF::Writer::writeGeometry(const COLLADAFW::Geometry* geometry) {
 }
 
 bool COLLADA2GLTF::Writer::writeMaterial(const COLLADAFW::Material* material) {
-	this->_materialEffects[material->getUniqueId()] = material->getInstantiatedEffect();
+	auto id = material->getUniqueId();
+	this->_materialEffects[id] = material->getInstantiatedEffect();
+	this->_materialName[id] = material->getName();
+
+	// TODO - read Material setting and properly apply to effect Instance
 	return true;
 }
 


### PR DESCRIPTION
A Material is an effect instance, and can change values on the instaced effect.
This PR introduces effect instances, and apply the material name to the instance, since this instance is directly the GLTF Material.
This fixes Material names in the exported gltf.

Other Material attributes marked as TODO in this PR.

Example material from the spec:
```
  <material id="Blue"> 
    <instance_effect  url="#phongEffect"> 
      <setparam ref="AMBIENT"> 
        <float3>0.0 0.0 0.1</float3> 
      </setparam> 
      <setparam ref="DIFFUSE"> 
        <float3>0.15 0.15 0.1</float3> 
      </setparam> 
      <setparam ref="SPECULAR"> 
        <float3>0.5 0.5 0.5</float3> 
      </setparam> 
      <setparam ref="SHININESS"> 
        <float>16.0</float> 
      </setparam> 
      </instance_effect> 
  </material>  
```