### PR TITLE
Added support alphaMode, alphaCutoff and doubleSided attributes for M…

### DIFF
--- a/GLTF/include/GLTFMaterial.h
+++ b/GLTF/include/GLTFMaterial.h
@@ -82,6 +82,14 @@ namespace GLTF {
 		Texture* emissiveTexture = NULL;
 		SpecularGlossiness* specularGlossiness = NULL;
 
+		/** Either "OPAQUE", "BLEND" or "MASK". Default = "OPAQUE" */
+		std::string alphaMode;
+
+		/** Only when alphaMode == "MASK". Default = 0.5 */
+		float alphaCutoff = NAN;
+
+		bool doubleSided = false;
+
 		MaterialPBR();
 		void writeJSON(void* writer, GLTF::Options* options);
 	};

--- a/GLTF/include/GLTFMaterial.h
+++ b/GLTF/include/GLTFMaterial.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string>
+#include <cmath>
 
 #include "GLTFObject.h"
 #include "GLTFTechnique.h"

--- a/GLTF/src/GLTFMaterial.cpp
+++ b/GLTF/src/GLTFMaterial.cpp
@@ -232,20 +232,17 @@ void GLTF::MaterialPBR::writeJSON(void* writer, GLTF::Options* options) {
 		jsonWriter->EndObject();
 	}
 
-	if (!this->alphaMode.empty())
-	{
+	if (!this->alphaMode.empty()) {
 		jsonWriter->Key("alphaMode");
 		jsonWriter->String(this->alphaMode.c_str());
 
-		if (this->alphaMode == "MASK" && !isnan(this->alphaCutoff))
-		{
+		if (this->alphaMode == "MASK" && !isnan(this->alphaCutoff)) {
 			jsonWriter->Key("alphaCutoff");
 			jsonWriter->Double(this->alphaCutoff);
 		}
 	}
 
-	if (this->doubleSided)
-	{
+	if (this->doubleSided) {
 		jsonWriter->Key("doubleSided");
 		jsonWriter->Bool(true);
 	}

--- a/GLTF/src/GLTFMaterial.cpp
+++ b/GLTF/src/GLTFMaterial.cpp
@@ -231,6 +231,25 @@ void GLTF::MaterialPBR::writeJSON(void* writer, GLTF::Options* options) {
 		jsonWriter->EndObject();
 		jsonWriter->EndObject();
 	}
+
+	if (!this->alphaMode.empty())
+	{
+		jsonWriter->Key("alphaMode");
+		jsonWriter->String(this->alphaMode.c_str());
+
+		if (this->alphaMode == "MASK" && !isnan(this->alphaCutoff))
+		{
+			jsonWriter->Key("alphaCutoff");
+			jsonWriter->Double(this->alphaCutoff);
+		}
+	}
+
+	if (this->doubleSided)
+	{
+		jsonWriter->Key("doubleSided");
+		jsonWriter->Bool(true);
+	}
+
 	GLTF::Object::writeJSON(writer, options);
 }
 

--- a/GLTF/src/GLTFMaterial.cpp
+++ b/GLTF/src/GLTFMaterial.cpp
@@ -236,7 +236,7 @@ void GLTF::MaterialPBR::writeJSON(void* writer, GLTF::Options* options) {
 		jsonWriter->Key("alphaMode");
 		jsonWriter->String(this->alphaMode.c_str());
 
-		if (this->alphaMode == "MASK" && !isnan(this->alphaCutoff)) {
+		if (this->alphaMode == "MASK" && !std::isnan(this->alphaCutoff)) {
 			jsonWriter->Key("alphaCutoff");
 			jsonWriter->Double(this->alphaCutoff);
 		}


### PR DESCRIPTION
For my Maya2glTF project, I needed support for `alphaMode` on materials.

I also added support for `alphaCutoff` and `doubleSided`.

I'm not sure if my changes are, please review. 

Thanks a lot for either feedback or acceptance!
