### PR TITLE
Double sided materials

### DIFF
--- a/GLTF/include/GLTFMaterial.h
+++ b/GLTF/include/GLTFMaterial.h
@@ -36,6 +36,7 @@ namespace GLTF {
 		GLTF::Technique* technique = NULL;
 		Type type = Type::UNKNOWN;
 		Values* values = NULL;
+		bool doubleSided = false;
 
 		Material();
 		bool hasTexture();
@@ -126,7 +127,7 @@ namespace GLTF {
 		GLTF::Material* getMaterial(std::vector<GLTF::MaterialCommon::Light*> lights, GLTF::Options* options);
 		GLTF::Material* getMaterial(std::vector<GLTF::MaterialCommon::Light*> lights, bool hasColorAttribute, GLTF::Options* options);
 		std::string getTechniqueKey(GLTF::Options* options);
-		GLTF::MaterialPBR* getMaterialPBR(bool specularGlossiness);
+		GLTF::MaterialPBR* getMaterialPBR(GLTF::Options* options);
 		virtual void writeJSON(void* writer, GLTF::Options* options);
 	};
 }

--- a/GLTF/include/GLTFMaterial.h
+++ b/GLTF/include/GLTFMaterial.h
@@ -116,7 +116,6 @@ namespace GLTF {
 			virtual void writeJSON(void* writer, GLTF::Options* options);
 		};
 
-		bool doubleSided = false;
 		int jointCount = 0;
 		bool transparent = false;
 
@@ -124,9 +123,9 @@ namespace GLTF {
 
 		MaterialCommon();
 		const char* getTechniqueName();
-		GLTF::Material* getMaterial(std::vector<GLTF::MaterialCommon::Light*> lights);
-		GLTF::Material* getMaterial(std::vector<GLTF::MaterialCommon::Light*> lights, bool hasColorAttribute);
-		std::string getTechniqueKey();
+		GLTF::Material* getMaterial(std::vector<GLTF::MaterialCommon::Light*> lights, GLTF::Options* options);
+		GLTF::Material* getMaterial(std::vector<GLTF::MaterialCommon::Light*> lights, bool hasColorAttribute, GLTF::Options* options);
+		std::string getTechniqueKey(GLTF::Options* options);
 		GLTF::MaterialPBR* getMaterialPBR(bool specularGlossiness);
 		virtual void writeJSON(void* writer, GLTF::Options* options);
 	};

--- a/GLTF/include/GLTFOptions.h
+++ b/GLTF/include/GLTFOptions.h
@@ -16,6 +16,7 @@ namespace GLTF {
 		bool binary = false;
 		bool lockOcclusionMetallicRoughness = false;
 		bool materialsCommon = false;
+		bool doubleSided = false;
 		bool glsl = false;
 		bool specularGlossiness = false;
 		std::vector<std::string> metallicRoughnessTexturePaths;

--- a/GLTF/src/GLTFAsset.cpp
+++ b/GLTF/src/GLTFAsset.cpp
@@ -774,7 +774,7 @@ void GLTF::Asset::writeJSON(void* writer, GLTF::Options* options) {
 						if (material->type == GLTF::Material::Type::MATERIAL_COMMON) {
 							GLTF::MaterialCommon* materialCommon = (GLTF::MaterialCommon*)material;
 							if (options->glsl) {
-								std::string techniqueKey = materialCommon->getTechniqueKey();
+								std::string techniqueKey = materialCommon->getTechniqueKey(options);
 								std::map<std::string, GLTF::Technique*>::iterator findTechnique = generatedTechniques.find(techniqueKey);
 								if (findTechnique != generatedTechniques.end()) {
 									material = new GLTF::Material();
@@ -784,7 +784,7 @@ void GLTF::Asset::writeJSON(void* writer, GLTF::Options* options) {
 								}
 								else {
 									bool hasColor = primitive->attributes.find("COLOR_0") != primitive->attributes.end();
-									material = materialCommon->getMaterial(lights, hasColor);
+									material = materialCommon->getMaterial(lights, hasColor, options);
 									generatedTechniques[techniqueKey] = material->technique;
 								}
 							}
@@ -1022,9 +1022,12 @@ void GLTF::Asset::writeJSON(void* writer, GLTF::Options* options) {
 					}
 				}
 			}
-
 			jsonWriter->StartObject();
-			material->writeJSON(writer, options);
+			if (options->doubleSided && !options->materialsCommon) {
+				jsonWriter->Key("doubleSided");
+				jsonWriter->Bool(true);
+			}
+ 			material->writeJSON(writer, options);
 			jsonWriter->EndObject();
 		}
 		jsonWriter->EndArray();

--- a/GLTF/src/GLTFAsset.cpp
+++ b/GLTF/src/GLTFAsset.cpp
@@ -789,7 +789,7 @@ void GLTF::Asset::writeJSON(void* writer, GLTF::Options* options) {
 								}
 							}
 							else {
-								GLTF::MaterialPBR* materialPbr = materialCommon->getMaterialPBR(options->specularGlossiness);
+								GLTF::MaterialPBR* materialPbr = materialCommon->getMaterialPBR(options);
 								if (options->lockOcclusionMetallicRoughness && materialPbr->occlusionTexture != NULL) {
 									GLTF::MaterialPBR::Texture* metallicRoughnessTexture = new GLTF::MaterialPBR::Texture();
 									metallicRoughnessTexture->texture = materialPbr->occlusionTexture->texture;
@@ -1023,11 +1023,7 @@ void GLTF::Asset::writeJSON(void* writer, GLTF::Options* options) {
 				}
 			}
 			jsonWriter->StartObject();
-			if (options->doubleSided && !options->materialsCommon) {
-				jsonWriter->Key("doubleSided");
-				jsonWriter->Bool(true);
-			}
- 			material->writeJSON(writer, options);
+			material->writeJSON(writer, options);
 			jsonWriter->EndObject();
 		}
 		jsonWriter->EndArray();

--- a/GLTF/src/GLTFMaterial.cpp
+++ b/GLTF/src/GLTFMaterial.cpp
@@ -293,11 +293,11 @@ const char* GLTF::MaterialCommon::getTechniqueName() {
 	return NULL;
 }
 
-GLTF::Material* GLTF::MaterialCommon::getMaterial(std::vector<GLTF::MaterialCommon::Light*> lights) {
-	return getMaterial(lights, false);
+GLTF::Material* GLTF::MaterialCommon::getMaterial(std::vector<GLTF::MaterialCommon::Light*> lights, GLTF::Options* options) {
+	return getMaterial(lights, false, options);
 }
 
-GLTF::Material* GLTF::MaterialCommon::getMaterial(std::vector<GLTF::MaterialCommon::Light*> lights, bool hasColor) {
+GLTF::Material* GLTF::MaterialCommon::getMaterial(std::vector<GLTF::MaterialCommon::Light*> lights, bool hasColor, GLTF::Options* options) {
 	GLTF::Material* material = new GLTF::Material();
 	material->values = values;
 	GLTF::Technique* technique = new GLTF::Technique();
@@ -467,7 +467,7 @@ GLTF::Material* GLTF::MaterialCommon::getMaterial(std::vector<GLTF::MaterialComm
 		technique->blendFuncSeparate.push_back(GLTF::Constants::WebGL::ONE);
 		technique->blendFuncSeparate.push_back(GLTF::Constants::WebGL::ONE_MINUS_SRC_ALPHA);
 	}
-	else if (doubleSided) {
+	else if (options->doubleSided) {
 		technique->enableStates.insert(GLTF::Constants::WebGL::DEPTH_TEST);
 	}
 	else {
@@ -664,7 +664,7 @@ void main(void) {\n";
 	}
 	if (hasNormals) {
 		fragmentShaderSource += "    vec3 normal = normalize(v_normal);\n";
-		if (doubleSided) {
+		if (options->doubleSided) {
 			fragmentShaderSource += "\
     if (gl_FrontFacing == false)\n\
     {\n\
@@ -755,7 +755,7 @@ void main(void) {\n";
 	return material;
 }
 
-std::string GLTF::MaterialCommon::getTechniqueKey() {
+std::string GLTF::MaterialCommon::getTechniqueKey(GLTF::Options* options) {
 	std::string id = "";
 	if (values->ambient != NULL) {
 		id += "AMBIENT;";
@@ -778,7 +778,7 @@ std::string GLTF::MaterialCommon::getTechniqueKey() {
 	if (values->transparency != NULL) {
 		id += "TRANSPARENCY;";
 	}
-	if (doubleSided) {
+	if (options->doubleSided) {
 		id += "DOUBLESIDED;";
 	}
 	if (transparent) {
@@ -865,7 +865,7 @@ void GLTF::MaterialCommon::writeJSON(void* writer, GLTF::Options* options) {
 	jsonWriter->Key("KHR_materials_common");
 	jsonWriter->StartObject();
 	jsonWriter->Key("doubleSided");
-	jsonWriter->Bool(this->doubleSided);
+	jsonWriter->Bool(options->doubleSided);
 	if (this->jointCount > 0) {
 		jsonWriter->Key("jointCount");
 		jsonWriter->Int(this->jointCount);

--- a/include/COLLADA2GLTFExtrasHandler.h
+++ b/include/COLLADA2GLTFExtrasHandler.h
@@ -26,7 +26,7 @@ namespace COLLADA2GLTF {
 	public:
 		std::set<COLLADAFW::UniqueId> lockAmbientDiffuse;
 		COLLADAFW::TextureAttributes* bumpTexture = NULL;
-		bool doubleSided = false;
+		std::set<COLLADAFW::UniqueId> doubleSided;
 		ExtrasHandler(COLLADASaxFWL::Loader* loader) : _loader(loader) {};
 	};
 }

--- a/include/COLLADA2GLTFExtrasHandler.h
+++ b/include/COLLADA2GLTFExtrasHandler.h
@@ -11,7 +11,7 @@ namespace COLLADA2GLTF {
 	private:
 		virtual bool elementBegin(const COLLADASaxFWL::ParserChar* elementName, const GeneratedSaxParser::xmlChar** attributes);
 		virtual bool elementEnd(const COLLADASaxFWL::ParserChar* elementName);
-		virtual bool textData(const COLLADASaxFWL::ParserChar* text, size_t textLength) { return true; }
+		virtual bool textData(const COLLADASaxFWL::ParserChar* text, size_t textLength);
 
 		virtual bool parseElement(
 			const COLLADASaxFWL::ParserChar* profileName,
@@ -22,10 +22,11 @@ namespace COLLADA2GLTF {
 		COLLADASaxFWL::Loader* _loader;
 		COLLADAFW::UniqueId _currentId;
 		bool _inBump = false;
+		bool _inDoubleSided = false;
 	public:
 		std::set<COLLADAFW::UniqueId> lockAmbientDiffuse;
 		COLLADAFW::TextureAttributes* bumpTexture = NULL;
-
+		bool doubleSided = false;
 		ExtrasHandler(COLLADASaxFWL::Loader* loader) : _loader(loader) {};
 	};
 }

--- a/src/COLLADA2GLTFExtrasHandler.cpp
+++ b/src/COLLADA2GLTFExtrasHandler.cpp
@@ -66,7 +66,7 @@ bool COLLADA2GLTF::ExtrasHandler::textData(const COLLADASaxFWL::ParserChar* text
 	if (_inDoubleSided) {
 		std::string flag = std::string(text, textLength);
 		if (flag == "1") {
-			doubleSided = true;
+			doubleSided.insert(_currentId);
 		}
 	}
 	return true;

--- a/src/COLLADA2GLTFExtrasHandler.cpp
+++ b/src/COLLADA2GLTFExtrasHandler.cpp
@@ -36,6 +36,9 @@ bool COLLADA2GLTF::ExtrasHandler::elementBegin(const COLLADASaxFWL::ParserChar* 
 			attributeKey = attributes[index++];
 		}
 	}
+	else if (name == "double_sided") {
+		_inDoubleSided = true;
+	}
 	return true;
 }
 
@@ -43,6 +46,9 @@ bool COLLADA2GLTF::ExtrasHandler::elementEnd(const COLLADASaxFWL::ParserChar* el
 	std::string name = std::string(elementName);
 	if (name == "bump") {
 		_inBump = false;
+	}
+	else if (name == "double_sided") {
+		_inDoubleSided = false;
 	}
 	return true; 
 }
@@ -53,5 +59,15 @@ bool COLLADA2GLTF::ExtrasHandler::parseElement(
 	const COLLADAFW::UniqueId& uniqueId,
 	COLLADAFW::Object* object) {
 	_currentId = uniqueId;
+	return true;
+}
+
+bool COLLADA2GLTF::ExtrasHandler::textData(const COLLADASaxFWL::ParserChar* text, size_t textLength) {
+	if (_inDoubleSided) {
+		std::string flag = std::string(text, textLength);
+		if (flag == "1") {
+			doubleSided = true;
+		}
+	}
 	return true;
 }

--- a/src/COLLADA2GLTFWriter.cpp
+++ b/src/COLLADA2GLTFWriter.cpp
@@ -816,6 +816,9 @@ bool COLLADA2GLTF::Writer::writeGeometry(const COLLADAFW::Geometry* geometry) {
 }
 
 bool COLLADA2GLTF::Writer::writeMaterial(const COLLADAFW::Material* material) {
+	if (this->_extrasHandler->doubleSided) {
+		this->_options->doubleSided = true;
+	}
 	this->_materialEffects[material->getUniqueId()] = material->getInstantiatedEffect();
 	return true;
 }

--- a/src/COLLADA2GLTFWriter.cpp
+++ b/src/COLLADA2GLTFWriter.cpp
@@ -816,9 +816,6 @@ bool COLLADA2GLTF::Writer::writeGeometry(const COLLADAFW::Geometry* geometry) {
 }
 
 bool COLLADA2GLTF::Writer::writeMaterial(const COLLADAFW::Material* material) {
-	if (this->_extrasHandler->doubleSided) {
-		this->_options->doubleSided = true;
-	}
 	this->_materialEffects[material->getUniqueId()] = material->getInstantiatedEffect();
 	return true;
 }
@@ -940,6 +937,11 @@ bool COLLADA2GLTF::Writer::writeEffect(const COLLADAFW::Effect* effect) {
 		if (_extrasHandler->bumpTexture != NULL) {
 			material->values->bumpTexture = fromColladaTexture(effectCommon, _extrasHandler->bumpTexture->samplerId);
 			_extrasHandler->bumpTexture = NULL;
+		}
+
+		bool doubleSided = _extrasHandler->doubleSided.find(effect->getUniqueId()) != _extrasHandler->doubleSided.end();
+		if (doubleSided) {
+			material->doubleSided = true;
 		}
 
 		this->_effectInstances[effect->getUniqueId()] = material;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -70,6 +70,10 @@ int main(int argc, const char **argv) {
 		->defaults(false)
 		->description("output materials using the KHR_materials_common extension");
 
+	parser->define("doubleSided", &options->doubleSided)
+		->defaults(false)
+		->description("output double sided materials. When this value is true, back-face culling is disabled and double sided lighting is enabled");
+
 	parser->define("metallicRoughnessTextures", &options->metallicRoughnessTexturePaths)
 		->description("paths to images to use as the PBR metallicRoughness textures");
 


### PR DESCRIPTION
Changes to allow double-sided common materials to be specified both from command line and within the COLLADA file.

This is used to correctly display fault planes in geological models.
