### PR TITLE
UNSIGNED_INT Fix for Vertex Indices

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,14 +97,18 @@ if(PRECOMPILED_DIR)
     ${PRECOMPILED_DIR}/pcre.lib)
 endif()
 
-# COLLADASaxFrameworkLoader/BaseUtils/Framework, GeneratedSaxParser
-include_directories(dependencies/OpenCOLLADA/OpenCOLLADA/COLLADASaxFrameworkLoader/include)
-include_directories(dependencies/OpenCOLLADA/OpenCOLLADA/COLLADABaseUtils/include)
-include_directories(dependencies/OpenCOLLADA/OpenCOLLADA/COLLADAFramework/include)
-include_directories(dependencies/OpenCOLLADA/OpenCOLLADA/GeneratedSaxParser/include)
-if(NOT OpenCOLLADA)
-  add_subdirectory(dependencies/OpenCOLLADA/modules/COLLADASaxFrameworkLoader)
-  set(OpenCOLLADA COLLADASaxFrameworkLoader)
+if(NOT DEFINED COLLADA_LIBRARIES AND NOT DEFINED COLLADA_FRAMEWORK_LIBRARIES)
+  # COLLADASaxFrameworkLoader/BaseUtils/Framework, GeneratedSaxParser
+  include_directories(dependencies/OpenCOLLADA/OpenCOLLADA/COLLADASaxFrameworkLoader/include)
+  include_directories(dependencies/OpenCOLLADA/OpenCOLLADA/COLLADABaseUtils/include)
+  include_directories(dependencies/OpenCOLLADA/OpenCOLLADA/COLLADAFramework/include)
+  include_directories(dependencies/OpenCOLLADA/OpenCOLLADA/GeneratedSaxParser/include)
+  if(NOT OpenCOLLADA)
+    add_subdirectory(dependencies/OpenCOLLADA/modules/COLLADASaxFrameworkLoader)
+    set(OpenCOLLADA COLLADASaxFrameworkLoader)
+  endif()
+else()
+  set(OpenCOLLADA ${COLLADA_LIBRARIES} ${COLLADA_FRAMEWORK_LIBRARIES})
 endif()
 
 # COLLADA2GLTF

--- a/GLTF/include/GLTFOptions.h
+++ b/GLTF/include/GLTFOptions.h
@@ -26,5 +26,6 @@ namespace GLTF {
 		int texcoordQuantizationBits = 10;
 		int colorQuantizationBits = 8;
 		int jointQuantizationBits = 8;
+		bool useUintIndices = false;
 	};
 }

--- a/src/COLLADA2GLTFWriter.cpp
+++ b/src/COLLADA2GLTFWriter.cpp
@@ -684,7 +684,7 @@ bool COLLADA2GLTF::Writer::writeMesh(const COLLADAFW::Mesh* colladaMesh) {
 				                                        GLTF::Constants::WebGL::UNSIGNED_INT : GLTF::Constants::WebGL::UNSIGNED_SHORT;
 
 				// If necessary, build a temporary (smaller) vector of shorts
-				std::vector<unsigned int> tempBuildIndices;
+				std::vector<unsigned short> tempBuildIndices;
 				if (componentType == GLTF::Constants::WebGL::UNSIGNED_SHORT) {
 					tempBuildIndices.reserve(buildIndices.size());
 					for(const auto& index : buildIndices) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -101,6 +101,10 @@ int main(int argc, const char **argv) {
 	parser->define("qj", &options->jointQuantizationBits)
 		->description("joint indices and weights quantization bits used in Draco compression extension");
 
+	parser->define("uint", &options->useUintIndices)
+		->defaults(false)
+		->description("use OES_element_index_uint extension to allow 32-bit vertex indices");
+
 	if (parser->parse(argc, argv)) {
 		// Resolve and sanitize paths
 		path inputPath = path(options->inputPath);


### PR DESCRIPTION
To resolve #123, attempt to use UNSIGNED_INT values for vertex indices iff the --uint command-line flag is specified and more than 2^16 unique vertex indices have been used in this primitive. Changes are also meant to make twiddling with this easier in the future by introducing index_t and signed_index_t types in `COLLADA2GLTF::Writer`.