### PR TITLE
PBR Texture scale is now a float

### DIFF
--- a/GLTF/include/GLTFMaterial.h
+++ b/GLTF/include/GLTFMaterial.h
@@ -51,7 +51,7 @@ namespace GLTF {
 			GLTF::Texture* texture = NULL;
 			int texCoord = -1;
 
-			virtual void writeJSON(void* writer, GLTF::Options* options);
+			void writeJSON(void* writer, GLTF::Options* options);
 		};
 
 		class MetallicRoughness : public GLTF::Object {

--- a/GLTF/include/GLTFMaterial.h
+++ b/GLTF/include/GLTFMaterial.h
@@ -47,11 +47,11 @@ namespace GLTF {
 	public: 
 		class Texture : public GLTF::Object {
 		public:
-			int scale = -1;
+			float scale = 1;
 			GLTF::Texture* texture = NULL;
 			int texCoord = -1;
 
-			void writeJSON(void* writer, GLTF::Options* options);
+			virtual void writeJSON(void* writer, GLTF::Options* options);
 		};
 
 		class MetallicRoughness : public GLTF::Object {

--- a/GLTF/src/GLTFMaterial.cpp
+++ b/GLTF/src/GLTFMaterial.cpp
@@ -102,10 +102,10 @@ void GLTF::Material::writeJSON(void* writer, GLTF::Options* options) {
 }
 
 void GLTF::MaterialPBR::Texture::writeJSON(void* writer, GLTF::Options* options) {
-	rapidjson::Writer<rapidjson::StringBuffer>* jsonWriter = (rapidjson::Writer<rapidjson::StringBuffer>*)writer;
-	if (scale >= 0) {
+	rapidjson::Writer<rapidjson::StringBuffer>* jsonWriter = static_cast<rapidjson::Writer<rapidjson::StringBuffer>*>(writer);
+	if (scale != 1) {
 		jsonWriter->Key("scale");
-		jsonWriter->Int(scale);
+		jsonWriter->Double(scale);
 	}
 	if (texture) {
 		jsonWriter->Key("index");


### PR DESCRIPTION
The PBR texture `scale` was an `int`, but according to the spec, it should be `float`.

Also, the default scale of `1` is not written to the output JSON.
