### PR TITLE
Fixed PBR material not registering emissiveTexture

### DIFF
--- a/GLTF/src/GLTFAsset.cpp
+++ b/GLTF/src/GLTFAsset.cpp
@@ -1005,6 +1005,11 @@ void GLTF::Asset::writeJSON(void* writer, GLTF::Options* options) {
 					occlusionTexture->texture->id = textures.size();
 					textures.push_back(occlusionTexture->texture);
 				}
+				GLTF::MaterialPBR::Texture* emissiveTexture = materialPBR->emissiveTexture;
+				if (emissiveTexture != NULL && emissiveTexture->texture->id < 0) {
+					emissiveTexture->texture->id = textures.size();
+					textures.push_back(emissiveTexture->texture);
+				}
 				if (options->specularGlossiness) {
 					if (!usesSpecularGlossiness) {
 						this->useExtension("KHR_materials_pbrSpecularGlossiness");


### PR DESCRIPTION
The `emissiveTexture` didn't get its `id` assigned, because it was not registered in the `textures` vector.

