### PR TITLE
Fix for image byte string that starts with null character

### DIFF
--- a/GLTF/src/GLTFImage.cpp
+++ b/GLTF/src/GLTFImage.cpp
@@ -12,7 +12,8 @@ std::map<std::string, GLTF::Image*> _imageCache;
 GLTF::Image::Image(std::string uri) : uri(uri) {}
 
 GLTF::Image::Image(std::string uri, unsigned char* data, size_t byteLength, std::string fileExtension) : uri(uri), data(data), byteLength(byteLength) {
-	if (std::string((char*)data, 1, 8) == "PNG\r\n\x1a\n") {
+	std::string dataSubstring((char*)data, 9);
+	if (dataSubstring.substr(1, 8) == "PNG\r\n\x1a\n") {
 		mimeType = "image/png";
 	}
 	else if (data[0] == 255 && data[1] == 216) {


### PR DESCRIPTION
Some image types, `.tga` in this case, allow the file to be started with `null` characters.

When creating an `std::string` from such a string, the `std::string` created assumes the first `null` character as the terminator, causing the size to be 0. This won't throw an exception, but its not the desired behavior in this case.

However, when creating an `std::string` from such a string with start and offset (existing code), the constructor believes that indices provided are out of bounds and throws an exception.

The way to fix this is to first create a string with a defined size, overriding the null character check. Then a substring can be created from this string.

Here is some standalone sample code to demonstrate this:
```
#include <iostream>
#include <stdexcept>

void foo(const char *bar, size_t length) {
    try {
        std::string str(bar);
        std::cout << "Size = " << str.size() << "\tString = " << str << std::endl;
    } catch(std::exception& e) {
        std::cerr << "Exception caught (1): " << e.what() << std::endl;
    }

    try {
        std::string str(bar, 0, length);
        std::cout << "Size = " << str.size() << "\tString = " << str << std::endl;
    } catch(std::exception& e) {
        std::cerr << "Exception caught (2): " << e.what() << std::endl;
    }
    
    try {
        std::string str(bar, 1, length - 1);
        std::cout << "Size = " << str.size() << "\tString = " << str << std::endl;
    } catch(std::exception& e) {
        std::cerr << "Exception caught (3): " << e.what() << std::endl;
    }
    
    try {
        std::string str_(bar, length);
        std::string str = str_.substr(1, length - 1);
        std::cout << "Size = " << str.size() << "\tString = " << str << std::endl;
    } catch(std::exception& e) {
        std::cerr << "Exception caught (4): " << e.what() << std::endl;
    }
}

int main() {
    foo("abcdefghij", 10);
    std::cout << "==============================" << std::endl;
    foo("\0abcdefghij", 11);
    std::cout << "==============================" << std::endl;
    
    return 0;
}
```