### PR TITLE
GLTFImage is removed from image cache when destructed

### DIFF
--- a/GLTF/include/GLTFImage.h
+++ b/GLTF/include/GLTFImage.h
@@ -14,6 +14,8 @@ namespace GLTF {
 
 		Image(std::string uri);
 		Image(std::string uri, unsigned char* data, size_t byteLength, std::string fileExtension);
+		virtual ~Image();
+
 		static GLTF::Image* load(path path);
 		std::pair<int, int> getDimensions();
 		virtual std::string typeName();

--- a/GLTF/src/GLTFImage.cpp
+++ b/GLTF/src/GLTFImage.cpp
@@ -23,6 +23,13 @@ GLTF::Image::Image(std::string uri, unsigned char* data, size_t byteLength, std:
 	}
 }
 
+GLTF::Image::~Image()
+{
+	auto it = std::find_if(_imageCache.begin(), _imageCache.end(), [this](auto pair) { return pair.second == this; });
+	if (it != _imageCache.end())
+		_imageCache.erase(it);
+}
+
 GLTF::Image* GLTF::Image::load(path imagePath) {
 	std::string fileString = imagePath.string();
 	std::map<std::string, GLTF::Image*>::iterator imageCacheIt = _imageCache.find(fileString);

--- a/GLTF/src/GLTFImage.cpp
+++ b/GLTF/src/GLTFImage.cpp
@@ -1,5 +1,6 @@
 #include <iostream>
 #include <map>
+#include <algorithm>
 
 #include "Base64.h"
 #include "GLTFImage.h"
@@ -7,7 +8,8 @@
 #include "rapidjson/stringbuffer.h"
 #include "rapidjson/writer.h"
 
-std::map<std::string, GLTF::Image*> _imageCache;
+typedef std::map<std::string, GLTF::Image*> ImageCache;
+ImageCache _imageCache;
 
 GLTF::Image::Image(std::string uri) : uri(uri) {}
 
@@ -25,7 +27,9 @@ GLTF::Image::Image(std::string uri, unsigned char* data, size_t byteLength, std:
 
 GLTF::Image::~Image()
 {
-	auto it = std::find_if(_imageCache.begin(), _imageCache.end(), [this](auto pair) { return pair.second == this; });
+	const ImageCache::iterator it = std::find_if(_imageCache.begin(), _imageCache.end(), 
+		[this](std::pair<ImageCache::key_type, ImageCache::mapped_type> pair) { return pair.second == this; });
+
 	if (it != _imageCache.end())
 		_imageCache.erase(it);
 }


### PR DESCRIPTION
In my Maya2glTF exporter, I had crashes when running the exporter twice, because the global GLTF image cache still contained destructed images. This PR should fix that.

It could have done more re-factoring by passing the full-path that is used as a key in the map to the `GLTFImage` constructor; that would be faster for scenes having an insane amount of textures, but feels like overkill?



