### PR TITLE
Images are now removed from cache when destructed

### DIFF
--- a/GLTF/include/GLTFImage.h
+++ b/GLTF/include/GLTFImage.h
@@ -8,15 +8,23 @@ namespace GLTF {
 	public:
 		std::string uri;
 		unsigned char* data = NULL;
-		size_t byteLength;
+		size_t byteLength = 0;
 		std::string mimeType;
 		GLTF::BufferView* bufferView = NULL;
 
 		Image(std::string uri);
 		Image(std::string uri, unsigned char* data, size_t byteLength, std::string fileExtension);
+		virtual ~Image();
+
 		static GLTF::Image* load(path path);
 		std::pair<int, int> getDimensions();
 		virtual std::string typeName();
 		virtual void writeJSON(void* writer, GLTF::Options* options);
+
+	private:
+		const std::string cacheKey;
+
+		Image(std::string uri, std::string cacheKey);
+		Image(std::string uri, std::string cacheKey, unsigned char* data, size_t byteLength, std::string fileExtension);
 	};
 }

--- a/GLTF/src/GLTFImage.cpp
+++ b/GLTF/src/GLTFImage.cpp
@@ -9,9 +9,11 @@
 
 std::map<std::string, GLTF::Image*> _imageCache;
 
-GLTF::Image::Image(std::string uri) : uri(uri) {}
+GLTF::Image::Image(std::string uri, std::string cacheKey) : uri(uri), cacheKey(cacheKey) {}
 
-GLTF::Image::Image(std::string uri, unsigned char* data, size_t byteLength, std::string fileExtension) : uri(uri), data(data), byteLength(byteLength) {
+GLTF::Image::Image(std::string uri) : Image(uri, "") {}
+
+GLTF::Image::Image(std::string uri, std::string cacheKey, unsigned char* data, size_t byteLength, std::string fileExtension) : uri(uri), data(data), byteLength(byteLength), cacheKey(cacheKey) {
 	if (std::string((char*)data, 1, 8) == "PNG\r\n\x1a\n") {
 		mimeType = "image/png";
 	}
@@ -20,6 +22,14 @@ GLTF::Image::Image(std::string uri, unsigned char* data, size_t byteLength, std:
 	}
 	else {
 		mimeType = "image/" + fileExtension;
+	}
+}
+
+GLTF::Image::Image(std::string uri, unsigned char* data, size_t byteLength, std::string fileExtension) : Image(uri, "", data, byteLength, fileExtension) {}
+
+GLTF::Image::~Image() {
+	if (!cacheKey.empty()) {
+		_imageCache.erase(cacheKey);
 	}
 }
 
@@ -34,7 +44,7 @@ GLTF::Image* GLTF::Image::load(path imagePath) {
 	FILE* file = fopen(fileString.c_str(), "rb");
 	if (file == NULL) {
 		std::cout << "WARNING: Image uri: " << fileString << " could not be resolved " << std::endl;
-		image = new GLTF::Image(imagePath.filename().string());
+		image = new GLTF::Image(imagePath.filename().string(), fileString);
 	}
 	else {
 		fseek(file, 0, SEEK_END);
@@ -44,7 +54,7 @@ GLTF::Image* GLTF::Image::load(path imagePath) {
 		unsigned char* buffer = (unsigned char*)malloc(size);
 		int bytesRead = fread(buffer, sizeof(unsigned char), size, file);
 		fclose(file);
-		image = new GLTF::Image(imagePath.filename().string(), buffer, bytesRead, fileExtension);
+		image = new GLTF::Image(imagePath.filename().string(), fileString, buffer, bytesRead, fileExtension);
 	}
 	_imageCache[fileString] = image;
 	return image;


### PR DESCRIPTION
In my Maya2glTF exporter, I had crashes when running the exporter twice, because the global GLTF image cache still contained destructed images. 

This PR should fix that, it adds private constructors that remember the `cacheKey`, the destructor uses this key to remove from the cache.

