### PR TITLE
KhrMaterialsCommon crash

### DIFF
--- a/GLTF/GLTFEffect.cpp
+++ b/GLTF/GLTFEffect.cpp
@@ -50,6 +50,7 @@ namespace GLTF
         this->setName(source->getName());
         this->setValues(source->getValues());
         this->setLightingModel(source->getLightingModel());
+        this->setKhrMaterialsCommonValues(source->getKhrMaterialsCommonValues());
         this->_texcoordToSemantics = effect._texcoordToSemantics;
         this->_profile = effect._profile;
     }


### PR DESCRIPTION
Fixed crash where an effect is copied and uses the materials common extension. This only affects the 1.0 branch.