### PR TITLE
Upgrade to Draco 1.2.5

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,11 @@
 Change Log
 ==========
 
+### v2.1.2 - 2018-04-22
+
+##### Fixes :wrench:
+* Upgrade to Draco 1.2.5 [#179](https://github.com/KhronosGroup/COLLADA2GLTF/pull/179)
+
 ### v2.1.1 - 2018-04-04
 
 ##### Additions :tada:


### PR DESCRIPTION
For #178.

The CMake build for 1.3.0 is currently broken: https://github.com/google/draco/issues/372