### PR TITLE
Fix issues with exporting normal maps

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@ Change Log
 
 ##### Fixes :wrench:
 * Upgrade to Draco 1.2.5 [#179](https://github.com/KhronosGroup/COLLADA2GLTF/pull/179)
+* Fix issue with exporting normal maps [#182](https://github.com/KhronosGroup/COLLADA2GLTF/pull/182)
 
 ### v2.1.1 - 2018-04-04
 

--- a/GLTF/src/GLTFAsset.cpp
+++ b/GLTF/src/GLTFAsset.cpp
@@ -274,6 +274,12 @@ std::vector<GLTF::Texture*> GLTF::Asset::getAllTextures() {
 					uniqueTextures.insert(values->specularTexture);
 				}
 			}
+			if (values->bumpTexture != NULL) {
+				if (uniqueTextures.find(values->bumpTexture) == uniqueTextures.end()) {
+					textures.push_back(values->bumpTexture);
+					uniqueTextures.insert(values->bumpTexture);
+				}
+			}
 		}
 		else if (material->type == GLTF::Material::PBR_METALLIC_ROUGHNESS) {
 			GLTF::MaterialPBR* materialPBR = (GLTF::MaterialPBR*)material;
@@ -419,7 +425,8 @@ void GLTF::Asset::removeUnusedSemantics() {
 				if (semantic.find("TEXCOORD") != std::string::npos) {
 					std::map<std::string, GLTF::Accessor*>::iterator removeTexcoord = primitive->attributes.find(semantic);
 					if (semantic == "TEXCOORD_0") {
-						if (values->ambientTexture == NULL && values->diffuseTexture == NULL && values->emissionTexture == NULL && values->specularTexture == NULL) {
+						if (values->ambientTexture == NULL && values->diffuseTexture == NULL && values->emissionTexture == NULL && 
+								values->specularTexture == NULL && values->bumpTexture == NULL) {
 							std::map<std::string, GLTF::Accessor*>::iterator removeTexcoord = primitive->attributes.find(semantic);
 							primitive->attributes.erase(removeTexcoord);
 							removeAttributeFromDracoExtension(primitive, semantic);


### PR DESCRIPTION
Digging through some old issues: this fixes #76.

Surprised this hasn't come up again; I guess there aren't a lot of COLLADA models with bump maps.