### PR TITLE
Remove dependency on std::experimental::filesystem

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,15 +7,6 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 include(ExternalProject)
 
 project(${PROJECT_NAME})
-if(MSVC)
-  set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /MTd")
-  set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /MT")
-  set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} /MTd")
-  set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} /MT")
-  add_definitions(-D_CRT_SECURE_NO_WARNINGS)
-elseif(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
-  add_compile_options(-lstdc++fs)
-endif()
 
 # cmake -Dtest=ON to build with tests
 option(test "Build all tests." OFF)
@@ -112,26 +103,17 @@ include_directories(include)
 file(GLOB LIB_HEADERS "include/*.h")
 set(LIB_SOURCES src/COLLADA2GLTFWriter.cpp src/COLLADA2GLTFExtrasHandler.cpp)
 add_library(${PROJECT_NAME} ${LIB_HEADERS} ${LIB_SOURCES})
-if(MSVC)
-   target_link_libraries(${PROJECT_NAME} GLTF ${OpenCOLLADA})
-elseif(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
-   target_link_libraries(${PROJECT_NAME} GLTF ${OpenCOLLADA} stdc++fs)
-endif()
+ target_link_libraries(${PROJECT_NAME} GLTF ${OpenCOLLADA})
 
 # ahoy
 include_directories(dependencies/ahoy/include)
 add_subdirectory(dependencies/ahoy)
 
 add_executable(${PROJECT_NAME}-bin src/main.cpp)
-if(MSVC)
-   target_link_libraries(${PROJECT_NAME}-bin ${PROJECT_NAME} ahoy)
-elseif(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
-   target_link_libraries(${PROJECT_NAME}-bin ${PROJECT_NAME} ahoy stdc++fs)
-endif()
-
-target_link_libraries(${PROJECT_NAME}-bin draco)
+target_link_libraries(${PROJECT_NAME}-bin ${PROJECT_NAME} ahoy draco)
 
 if(TEST_ENABLED)
+  set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
   enable_testing()
 
   # gtest

--- a/GLTF/CMakeLists.txt
+++ b/GLTF/CMakeLists.txt
@@ -7,9 +7,6 @@ set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 project(${PROJECT_NAME})
-if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
-  add_compile_options(-lstdc++fs)
-endif()
 
 # cmake -Dtest=ON to build with tests
 option(test "Build all tests." OFF)
@@ -31,12 +28,6 @@ file(GLOB HEADERS "include/*.h")
 file(GLOB SOURCES "src/*.cpp")
 
 add_library(GLTF ${HEADERS} ${SOURCES})
-if(MSVC)
-   target_link_libraries(${PROJECT_NAME})
-elseif(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
-   target_link_libraries(${PROJECT_NAME} stdc++fs)
-endif()
-
 target_link_libraries(${PROJECT_NAME} draco)
 
 if (test)

--- a/GLTF/include/GLTFImage.h
+++ b/GLTF/include/GLTFImage.h
@@ -16,7 +16,7 @@ namespace GLTF {
 		Image(std::string uri, unsigned char* data, size_t byteLength, std::string fileExtension);
 		virtual ~Image();
 
-		static GLTF::Image* load(path path);
+		static GLTF::Image* load(std::string path);
 		std::pair<int, int> getDimensions();
 		virtual std::string typeName();
 		virtual void writeJSON(void* writer, GLTF::Options* options);

--- a/GLTF/include/GLTFOptions.h
+++ b/GLTF/include/GLTFOptions.h
@@ -2,9 +2,6 @@
 
 #include <string>
 #include <vector>
-#include <experimental/filesystem>
-
-using namespace std::experimental::filesystem;
 
 namespace GLTF {
 	class Options {

--- a/src/COLLADA2GLTFWriter.cpp
+++ b/src/COLLADA2GLTFWriter.cpp
@@ -1,10 +1,6 @@
 #include "COLLADA2GLTFWriter.h"
 
-#include <experimental/filesystem>
-
 #include "Base64.h"
-
-using namespace std::experimental::filesystem;
 
 const double PI = 3.14159;
 
@@ -1091,8 +1087,8 @@ bool COLLADA2GLTF::Writer::writeCamera(const COLLADAFW::Camera* colladaCamera) {
 
 bool COLLADA2GLTF::Writer::writeImage(const COLLADAFW::Image* colladaImage) {
 	const COLLADABU::URI imageUri = colladaImage->getImageURI();
-	path imagePath = path(_options->basePath) / imageUri.toNativePath(COLLADABU::Utils::getSystemType());
-	GLTF::Image* image = GLTF::Image::load(imagePath);
+	COLLADABU::URI resolvedPath = COLLADABU::URI(_options->basePath + imageUri.originalStr());
+	GLTF::Image* image = GLTF::Image::load(resolvedPath.toNativePath(COLLADABU::Utils::getSystemType()));
 	image->stringId = colladaImage->getOriginalId();
 	_images[colladaImage->getUniqueId()] = image;
 	return true;


### PR DESCRIPTION
Important step towards supporting OS X and emscripten builds natively.

I wish this was more widely adopted, which is why I chose it originally, but the ecosystem just isn't there yet.

Instead we do a little bit of string manipulation in the GLTF library and use the OpenCOLLADA URI and file utilities in the parts of the project that already depend on OpenCOLLADA.

Seems to work fine based on my initial testing.