### PR TITLE
Remove debug builds from CI

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -5,10 +5,6 @@ matrix:
   fast_finish: true
   allow_failures:
   - platform: x86
-    configuration: Debug
-  - platform: x64
-    configuration: Debug
-  - platform: x86
     configuration: Release
   - platform: x64
     configuration: Release
@@ -21,7 +17,6 @@ cache:
 - cmake-build
 
 configuration:
-- Debug
 - Release
 
 install:
@@ -31,8 +26,6 @@ install:
 before_build:
 - if not exist cmake-build mkdir cmake-build
 - cd cmake-build
-- if "%PLATFORM%"=="Win32" if "%CONFIGURATION%"=="Debug" cmake -G "Visual Studio 14 2015" .. -Dtest=ON
-- if "%PLATFORM%"=="x64" if "%CONFIGURATION%"=="Debug" cmake -G "Visual Studio 14 2015 Win64" .. -Dtest=ON
 - if "%PLATFORM%"=="Win32" if "%CONFIGURATION%"=="Release" cmake -G "Visual Studio 14 2015" .. -Dtest=ON
 - if "%PLATFORM%"=="x64" if "%CONFIGURATION%"=="Release" cmake -G "Visual Studio 14 2015 Win64" .. -Dtest=ON
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Change Log
 * Fixed issue with relative path resolution on Windows [#200](https://github.com/KhronosGroup/COLLADA2GLTF/issues/200)
 * Updated to OpenCOLLADA 1.6.63
   * Resolves issue where image elements declared in profile_COMMON are not written [#129](https://github.com/KhronosGroup/COLLADA2GLTF/issues/129) and [#114](https://github.com/KhronosGroup/COLLADA2GLTF/issues/114)
+* Remove Windows debug builds from CI - as per [Microsoft](https://docs.microsoft.com/en-us/previous-versions/visualstudio/visual-studio-6.0/aa260978(v=vs.60)#a-list-of-redistributable-files), they are not to be redistributed
 
 ### v2.1.3 - 2018-07-01
 


### PR DESCRIPTION
As per [Microsoft](https://docs.microsoft.com/en-us/previous-versions/visualstudio/visual-studio-6.0/aa260978(v=vs.60)#a-list-of-redistributable-files)

> Note that debug versions of an application are not redistributable

This seems to be a legal restriction, not necessarily a technical one. However, I'd rather err on the side of caution, plus this will make our Appveyor builds about twice as fast.