### PR TITLE
GLTFNode now sets camera pointer to NULL

### DIFF
--- a/GLTF/include/GLTFNode.h
+++ b/GLTF/include/GLTFNode.h
@@ -54,7 +54,7 @@ namespace GLTF {
 			TransformMatrix* getTransformMatrix();
 		};
 
-		GLTF::Camera* camera;
+		GLTF::Camera* camera = NULL;
 		std::vector<GLTF::Node*> children;
 		GLTF::Skin* skin = NULL;
 		std::string jointName;


### PR DESCRIPTION
This tiny fix caused crashes in [Maya2glTF](https://github.com/WonderMediaProductions/Maya2glTF).

Since all the other data members are set to `NULL`, I guess this is the appropriate thing to do for the `camera` data member too?


