### PR TITLE
Use earcut to triangulate polylist/polygons

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,3 +13,6 @@
 [submodule "dependencies/draco"]
 	path = GLTF/dependencies/draco
 	url = https://github.com/google/draco.git
+[submodule "dependencies/earcut.hpp"]
+	path = dependencies/earcut.hpp
+	url = https://github.com/mapbox/earcut.hpp.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,6 +109,9 @@ add_library(${PROJECT_NAME} ${LIB_HEADERS} ${LIB_SOURCES})
 include_directories(dependencies/ahoy/include)
 add_subdirectory(dependencies/ahoy)
 
+# earcut
+include_directories(dependencies/earcut.hpp/include)
+
 add_executable(${PROJECT_NAME}-bin src/main.cpp)
 target_link_libraries(${PROJECT_NAME}-bin ${PROJECT_NAME} ahoy draco)
 

--- a/include/COLLADA2GLTFWriter.h
+++ b/include/COLLADA2GLTFWriter.h
@@ -38,6 +38,7 @@ namespace COLLADA2GLTF {
 		std::map<COLLADAFW::UniqueId, std::vector<COLLADAFW::UniqueId>> _skinJointNodes;
 		std::map<COLLADAFW::UniqueId, std::tuple<GLTF::Accessor::Type, std::vector<int*>, std::vector<float*>>> _skinData;
 		std::map<COLLADAFW::UniqueId, GLTF::Mesh*> _skinnedMeshes;
+		std::map<COLLADAFW::UniqueId, bool> _skinnedMeshIsDoubleSided;
 		std::map<COLLADAFW::UniqueId, GLTF::Image*> _images;
 		std::map<COLLADAFW::UniqueId, std::tuple<std::vector<float>, std::vector<float>>> _animationData;
 		std::map<COLLADAFW::UniqueId, std::map<std::string, GLTF::Texture*>> _effectTextureMapping;

--- a/include/COLLADA2GLTFWriter.h
+++ b/include/COLLADA2GLTFWriter.h
@@ -28,6 +28,7 @@ namespace COLLADA2GLTF {
 		std::map<COLLADAFW::UniqueId, std::map<int, std::set<GLTF::Primitive*>>> _meshMaterialPrimitiveMapping;
 		std::map<COLLADAFW::UniqueId, GLTF::MaterialCommon::Light*> _lightInstances;
 		std::map<COLLADAFW::UniqueId, std::map<GLTF::Primitive*, std::vector<unsigned int>>> _meshPositionMapping;
+		std::map<COLLADAFW::UniqueId, bool> _meshIsDoubleSided;
 		std::map<GLTF::Mesh*, std::map<unsigned int, unsigned int>> _meshTexCoordSetMapping;
 		std::map<COLLADAFW::UniqueId, GLTF::Skin*> _skinInstances;
 		std::map<COLLADAFW::UniqueId, GLTF::Node*> _animatedNodes;

--- a/src/COLLADA2GLTFWriter.cpp
+++ b/src/COLLADA2GLTFWriter.cpp
@@ -262,6 +262,10 @@ bool COLLADA2GLTF::Writer::writeNodeToGroup(std::vector<GLTF::Node*>* group, con
 					GLTF::MaterialCommon* materialCommon = (GLTF::MaterialCommon*)material;
 					materialCommon->jointCount = _skinJointNodes[uniqueId].size();
 				}
+				if (_skinnedMeshIsDoubleSided[uniqueId]) {
+					material->doubleSided = true;
+				}
+				primitive->material = material;
 			}
 
 			for (const COLLADABU::URI& skeletonURI : instanceController->skeletons()) {
@@ -632,6 +636,12 @@ bool COLLADA2GLTF::Writer::writeMesh(const COLLADAFW::Mesh* colladaMesh) {
 						float x = getMeshVertexDataAtIndex(*positions, index * 3);
 						float y = getMeshVertexDataAtIndex(*positions, index * 3 + 1);
 						float z = getMeshVertexDataAtIndex(*positions, index * 3 + 2);
+						xMin = std::min(x, xMin);
+						xMax = std::max(x, xMax);
+						yMin = std::min(y, yMin);
+						yMax = std::max(y, yMax);
+						zMin = std::min(z, zMin);
+						zMax = std::max(z, zMax);
 					}
 					float xRange = xMax - xMin;
 					float yRange = yMax - yMin;
@@ -1793,6 +1803,7 @@ bool COLLADA2GLTF::Writer::writeController(const COLLADAFW::Controller* controll
 
 		_skinInstances[skinControllerId] = skin;
 		_skinnedMeshes[skinControllerId] = mesh;
+		_skinnedMeshIsDoubleSided[skinControllerId] = _meshIsDoubleSided[meshId];
 	}
 	else if (controller->getControllerType() == COLLADAFW::Controller::CONTROLLER_TYPE_MORPH) {
 		COLLADAFW::MorphController* morphController = (COLLADAFW::MorphController*)controller;


### PR DESCRIPTION
For #201 

This goes along with transparency changes so that we don't introduce visual artifacts with transparent polygons. Overall, polygon/polylist meshes conversion should also produce smaller models.