### PR TITLE
We now properly handle instance_node that comes before the node within library_nodes

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -32,8 +32,8 @@ install:
 before_build:
 - if not exist cmake-build mkdir cmake-build
 - cd cmake-build
-- IF "%PLATFORM%"=="Win32" cmake -G "Visual Studio 14 2015" .. -Dtest=ON
-- IF "%PLATFORM%"=="x64" cmake -G "Visual Studio 14 2015 Win64" .. -Dtest=ON
+- IF "%PLATFORM%"=="Win32" cmake -G "Visual Studio 14 2015" .. -Dtest=ON -DCMAKE_CXX_FLAGS=/w
+- IF "%PLATFORM%"=="x64" cmake -G "Visual Studio 14 2015 Win64" .. -Dtest=ON -DCMAKE_CXX_FLAGS=/w
 
 build:
   parallel: true

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -32,8 +32,8 @@ install:
 before_build:
 - if not exist cmake-build mkdir cmake-build
 - cd cmake-build
-- IF "%PLATFORM%"=="Win32" cmake -G "Visual Studio 14 2015" .. -Dtest=ON -DCMAKE_CXX_FLAGS=/w
-- IF "%PLATFORM%"=="x64" cmake -G "Visual Studio 14 2015 Win64" .. -Dtest=ON -DCMAKE_CXX_FLAGS=/w
+- IF "%PLATFORM%"=="Win32" cmake -G "Visual Studio 14 2015" .. -Dtest=ON -DCMAKE_CXX_FLAGS=/Qspectre
+- IF "%PLATFORM%"=="x64" cmake -G "Visual Studio 14 2015 Win64" .. -Dtest=ON -DCMAKE_CXX_FLAGS=/Qspectre
 
 build:
   parallel: true

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -32,8 +32,8 @@ install:
 before_build:
 - if not exist cmake-build mkdir cmake-build
 - cd cmake-build
-- IF "%PLATFORM%"=="Win32" cmake -G "Visual Studio 14 2015" .. -Dtest=ON -DCMAKE_CXX_FLAGS=/Qspectre
-- IF "%PLATFORM%"=="x64" cmake -G "Visual Studio 14 2015 Win64" .. -Dtest=ON -DCMAKE_CXX_FLAGS=/Qspectre
+- IF "%PLATFORM%"=="Win32" cmake -G "Visual Studio 14 2015" .. -Dtest=ON -DCMAKE_CXX_FLAGS=/wd5045
+- IF "%PLATFORM%"=="x64" cmake -G "Visual Studio 14 2015 Win64" .. -Dtest=ON -DCMAKE_CXX_FLAGS=/wd5045
 
 build:
   parallel: true


### PR DESCRIPTION
This is a fix for 1.0 branch

Previously we would process the `visual_scene` hierarchy and once that was done we'd iterate over `library_nodes` and resolve any `instance_node` references that needed to be resolved.

The problem is when a `instance_node` is within the `library_nodes` hierarchy, these references are never resolved, so we end up with a glTF that can have meshes that are never reachable from the root node, so therefore never rendered.

This change essentially just moved the existing code to within `writeNode`. Now whenever a node is encountered regardless of where it is located, it resolves any previously encountered `instance_node` references to itself.