### PR TITLE
Tweaks to lighting and support for double sided models found in the wild

### DIFF
--- a/src/COLLADA2GLTFExtrasHandler.cpp
+++ b/src/COLLADA2GLTFExtrasHandler.cpp
@@ -65,7 +65,7 @@ bool COLLADA2GLTF::ExtrasHandler::parseElement(
 bool COLLADA2GLTF::ExtrasHandler::textData(const COLLADASaxFWL::ParserChar* text, size_t textLength) {
 	if (_inDoubleSided) {
 		std::string flag = std::string(text, textLength);
-		if (flag == "1") {
+		if (flag == "1" || flag == "true") {
 			doubleSided.insert(_currentId);
 		}
 	}


### PR DESCRIPTION
- Some models in the wild had `double_sided` tags that had `true` instead of `1`
- If a `transparent` color was specified we were using `OpaqueMode` of `RGB_ONE` which isn't even the default. You can see the formulas in the 1.4.1 and 1.5.0 specs in Chapter 7 under `Determining Transparency (Opacity)`. Note that 1.4.1 doesn't have `A_ZERO` or `RGB_ONE`, they were added in 1.5.0.