### PR TITLE
Frees memory when an asset goes away

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@ Change Log
 ##### Additions :tada:
 * Added support for morph targets [#166](https://github.com/KhronosGroup/COLLADA2GLTF/issues/166)
 * Support converting models with transparency [#168](https://github.com/KhronosGroup/COLLADA2GLTF/issues/168)
+* Clean up glTF tree when the asset is freed [#229](https://github.com/KhronosGroup/COLLADA2GLTF/issues/229)
 
 ### v2.1.4 - 2018-08-29
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,11 @@ set(TEST_ENABLED ${test})
 set(test OFF)
 
 # RapidJSON
-include_directories(GLTF/dependencies/rapidjson/include)
+if(DEFINED RAPIDJSON_INCLUDE_DIR)
+  include_directories(${RAPIDJSON_INCLUDE_DIR})
+else()
+  include_directories(GLTF/dependencies/rapidjson/include)
+endif()
 
 # Draco
 include_directories(GLTF/dependencies/draco/src)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,11 @@ else()
 endif()
 
 # Draco
-include_directories(GLTF/dependencies/draco/src)
+if(DEFINED DRACO_INCLUDE_DIR)
+  include_directories(${DRACO_INCLUDE_DIR})
+else()
+  include_directories(GLTF/dependencies/draco/src)
+endif()
 
 # Pre-compiled
 if(precompiled MATCHES "X86")
@@ -107,14 +111,16 @@ include_directories(include)
 file(GLOB LIB_HEADERS "include/*.h")
 set(LIB_SOURCES src/COLLADA2GLTFWriter.cpp src/COLLADA2GLTFExtrasHandler.cpp)
 add_library(${PROJECT_NAME} ${LIB_HEADERS} ${LIB_SOURCES})
- target_link_libraries(${PROJECT_NAME} GLTF ${OpenCOLLADA})
+target_link_libraries(${PROJECT_NAME} GLTF ${OpenCOLLADA})
 
 # ahoy
 include_directories(dependencies/ahoy/include)
 add_subdirectory(dependencies/ahoy)
 
-add_executable(${PROJECT_NAME}-bin src/main.cpp)
-target_link_libraries(${PROJECT_NAME}-bin ${PROJECT_NAME} ahoy draco)
+if(NOT NO_COLLADA2GLTF_BIN)
+  add_executable(${PROJECT_NAME}-bin src/main.cpp)
+  target_link_libraries(${PROJECT_NAME}-bin ${PROJECT_NAME} ahoy draco)
+endif()
 
 if(TEST_ENABLED)
   set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)

--- a/GLTF/CMakeLists.txt
+++ b/GLTF/CMakeLists.txt
@@ -12,7 +12,11 @@ project(${PROJECT_NAME})
 option(test "Build all tests." OFF)
 
 # RapidJSON
-include_directories(dependencies/rapidjson/include)
+if(DEFINED RAPIDJSON_INCLUDE_DIR)
+  include_directories(${RAPIDJSON_INCLUDE_DIR})
+else()
+  include_directories(dependencies/rapidjson/include)
+endif()
 
 # Draco
 include_directories(dependencies/draco/src)

--- a/GLTF/CMakeLists.txt
+++ b/GLTF/CMakeLists.txt
@@ -19,12 +19,16 @@ else()
 endif()
 
 # Draco
-include_directories(dependencies/draco/src)
-add_subdirectory(dependencies/draco)
-get_property(draco_targets DIRECTORY dependencies/draco PROPERTY BUILDSYSTEM_TARGETS)
-foreach(draco_target IN LISTS draco_targets)
+if(DEFINED DRACO_INCLUDE_DIR)
+  include_directories(${DRACO_INCLUDE_DIR})
+else()
+  include_directories(dependencies/draco/src)
+  add_subdirectory(dependencies/draco)
+  get_property(draco_targets DIRECTORY dependencies/draco PROPERTY BUILDSYSTEM_TARGETS)
+  foreach(draco_target IN LISTS draco_targets)
 	set_property(TARGET ${draco_target} PROPERTY FOLDER "draco")
-endforeach()
+  endforeach()
+endif()
 
 # gltf
 include_directories(include)

--- a/GLTF/include/GLTFAnimation.h
+++ b/GLTF/include/GLTFAnimation.h
@@ -33,6 +33,8 @@ namespace GLTF {
 
     class Channel : public GLTF::Object {
     public:
+        ~Channel();
+
 		class Target : public GLTF::Object {
 		public:
 			GLTF::Node* node;
@@ -41,11 +43,13 @@ namespace GLTF {
 			virtual void writeJSON(void* writer, GLTF::Options* options);
 		};
 
-		GLTF::Animation::Sampler* sampler;
-		Target* target;
+        GLTF::Animation::Sampler* sampler = nullptr;
+        Target* target = nullptr;
 
 		virtual void writeJSON(void* writer, GLTF::Options* options);
     };
+
+    ~Animation();
 
     std::vector<Channel*> channels;
 

--- a/GLTF/include/GLTFAsset.h
+++ b/GLTF/include/GLTFAsset.h
@@ -35,6 +35,8 @@ namespace GLTF {
 		int scene = -1;
 
 		Asset();
+        virtual ~Asset();
+
 		GLTF::Scene* getDefaultScene();
 		std::vector<GLTF::Accessor*> getAllAccessors();
 		std::vector<GLTF::Node*> getAllNodes();
@@ -48,6 +50,11 @@ namespace GLTF {
 		std::vector<GLTF::Texture*> getAllTextures();
 		std::vector<GLTF::Image*> getAllImages();
 		std::vector<GLTF::Accessor*> getAllPrimitiveAccessors(GLTF::Primitive* primitive) const;
+        std::vector<GLTF::BufferView*> getAllBufferViews();
+        std::vector<GLTF::Buffer*> getAllBuffers();
+        std::vector<GLTF::Camera*> getAllCameras();
+        std::vector<GLTF::MaterialCommon::Light*> getAllLights();
+
 		void mergeAnimations();
 		void removeUnusedSemantics();
 		void removeUnusedNodes(GLTF::Options* options);

--- a/GLTF/include/GLTFBuffer.h
+++ b/GLTF/include/GLTFBuffer.h
@@ -10,6 +10,7 @@ namespace GLTF {
 		std::string uri;
 
 		Buffer(unsigned char* data, int dataLength);
+        virtual ~Buffer();
 		
 		virtual std::string typeName();
 		virtual void writeJSON(void* writer, GLTF::Options* options);

--- a/GLTF/include/GLTFMaterial.h
+++ b/GLTF/include/GLTFMaterial.h
@@ -44,6 +44,7 @@ namespace GLTF {
 		bool doubleSided = false;
 
 		Material();
+        virtual ~Material();
 		bool hasTexture();
 		virtual std::string typeName();
 		virtual void writeJSON(void* writer, GLTF::Options* options);
@@ -51,6 +52,8 @@ namespace GLTF {
 
 	class MaterialPBR : public GLTF::Material {
 	public: 
+        virtual ~MaterialPBR();
+
 		class Texture : public GLTF::Object {
 		public:
 			float scale = 1;
@@ -62,6 +65,7 @@ namespace GLTF {
 
 		class MetallicRoughness : public GLTF::Object {
 		public:
+            virtual ~MetallicRoughness();
 			float* baseColorFactor = NULL;
 			Texture* baseColorTexture = NULL;
 			float metallicFactor = -1.0;
@@ -73,6 +77,7 @@ namespace GLTF {
 
 		class SpecularGlossiness : public GLTF::Object {
 		public:
+            virtual ~SpecularGlossiness();
 			float* diffuseFactor = NULL;
 			Texture* diffuseTexture = NULL;
 			float* specularFactor = NULL;

--- a/GLTF/include/GLTFMaterial.h
+++ b/GLTF/include/GLTFMaterial.h
@@ -44,7 +44,13 @@ namespace GLTF {
 		bool doubleSided = false;
 
 		Material();
-        virtual ~Material();
+		virtual ~Material();
+
+		Material(const Material&) = delete;
+		Material& operator=(const Material&) = delete;
+		Material(Material&&) = delete;
+		Material& operator=(Material&&) = delete;
+
 		bool hasTexture();
 		virtual std::string typeName();
 		virtual void writeJSON(void* writer, GLTF::Options* options);
@@ -52,7 +58,12 @@ namespace GLTF {
 
 	class MaterialPBR : public GLTF::Material {
 	public: 
-        virtual ~MaterialPBR();
+		virtual ~MaterialPBR();
+
+		MaterialPBR(const MaterialPBR&) = delete;
+		MaterialPBR& operator=(const MaterialPBR&) = delete;
+		MaterialPBR(MaterialPBR&&) = delete;
+		MaterialPBR& operator=(MaterialPBR&&) = delete;
 
 		class Texture : public GLTF::Object {
 		public:
@@ -143,6 +154,12 @@ namespace GLTF {
 		MaterialCommon::Technique technique = MaterialCommon::Technique::UNKNOWN;
 
 		MaterialCommon();
+
+		MaterialCommon(const MaterialCommon&) = delete;
+		MaterialCommon& operator=(const MaterialCommon&) = delete;
+		MaterialCommon(MaterialCommon&&) = delete;
+		MaterialCommon& operator=(MaterialCommon&&) = delete;
+
 		const char* getTechniqueName();
 		GLTF::Material* getMaterial(std::vector<GLTF::MaterialCommon::Light*> lights, GLTF::Options* options);
 		GLTF::Material* getMaterial(std::vector<GLTF::MaterialCommon::Light*> lights, bool hasColorAttribute, GLTF::Options* options);

--- a/GLTF/include/GLTFNode.h
+++ b/GLTF/include/GLTFNode.h
@@ -54,6 +54,8 @@ namespace GLTF {
 			TransformMatrix* getTransformMatrix();
 		};
 
+        ~Node();
+
 		GLTF::Camera* camera = NULL;
 		std::vector<GLTF::Node*> children;
 		GLTF::Skin* skin = NULL;

--- a/GLTF/include/GLTFObject.h
+++ b/GLTF/include/GLTFObject.h
@@ -10,6 +10,8 @@ namespace GLTF {
 	class Extension;
 	class Object {
 	public:
+        virtual ~Object();
+
 		int id = -1;
 		std::string stringId;
 		std::string name;

--- a/GLTF/include/GLTFPrimitive.h
+++ b/GLTF/include/GLTFPrimitive.h
@@ -36,6 +36,8 @@ namespace GLTF {
 		Mode mode = Mode::UNKNOWN;
 		std::vector<Target*> targets;
 
+        ~Primitive();
+
 		virtual GLTF::Object* clone(GLTF::Object* clone);
 		virtual void writeJSON(void* writer, GLTF::Options* options);
 	};

--- a/GLTF/include/GLTFTechnique.h
+++ b/GLTF/include/GLTFTechnique.h
@@ -24,6 +24,8 @@ namespace GLTF {
 			Parameter(std::string semantic, GLTF::Constants::WebGL type, int count) : semantic(semantic), type(type), count(count) {};
 		};
 
+        ~Technique();
+
 		std::map<std::string, Parameter*> parameters;
 		std::map<std::string, std::string> attributes;
 		std::map<std::string, std::string> uniforms;

--- a/GLTF/src/GLTFAnimation.cpp
+++ b/GLTF/src/GLTFAnimation.cpp
@@ -3,6 +3,8 @@
 #include "rapidjson/stringbuffer.h"
 #include "rapidjson/writer.h"
 
+#include <algorithm>
+
 std::string pathString(GLTF::Animation::Path path) {
 	switch (path) {
 	case GLTF::Animation::Path::TRANSLATION:

--- a/GLTF/src/GLTFAnimation.cpp
+++ b/GLTF/src/GLTFAnimation.cpp
@@ -17,6 +17,10 @@ std::string pathString(GLTF::Animation::Path path) {
 	return "unknown";
 }
 
+GLTF::Animation::~Animation() {
+    std::for_each(channels.begin(), channels.end(), std::default_delete<Channel>());
+}
+
 std::string GLTF::Animation::typeName() {
 	return "animation";
 }
@@ -139,6 +143,12 @@ void GLTF::Animation::Sampler::writeJSON(void* writer, GLTF::Options* options) {
 		jsonWriter->Int(output->id);
 	}
 	GLTF::Object::writeJSON(writer, options);
+}
+
+GLTF::Animation::Channel::~Channel()
+{
+    delete sampler;
+    delete target;
 }
 
 void GLTF::Animation::Channel::writeJSON(void* writer, GLTF::Options* options) {

--- a/GLTF/src/GLTFAsset.cpp
+++ b/GLTF/src/GLTFAsset.cpp
@@ -458,6 +458,15 @@ std::vector<GLTF::MaterialCommon::Light*> GLTF::Asset::getAllLights()
 {
     std::vector<GLTF::MaterialCommon::Light*> lights;
     std::set<GLTF::MaterialCommon::Light*> uniqueLights;
+
+    for (GLTF::Node* node : getAllNodes()) {
+        GLTF::MaterialCommon::Light* light = node->light;
+        if (uniqueLights.find(light) == uniqueLights.end()) {
+            lights.push_back(light);
+            uniqueLights.insert(light);
+        }
+    }
+
     for (GLTF::MaterialCommon::Light* light : _ambientLights) {
         if (uniqueLights.find(light) == uniqueLights.end()) {
             lights.push_back(light);

--- a/GLTF/src/GLTFAsset.cpp
+++ b/GLTF/src/GLTFAsset.cpp
@@ -46,9 +46,13 @@ GLTF::Asset::~Asset() {
     GLTFObjectDeleter(getAllCameras());
     GLTFObjectDeleter(getAllLights());
 
-    GLTFObjectDeleter(getAllSkins());
-
-    GLTFObjectDeleter(getAllNodes());
+    // Skins and nodes have some interdependency,
+    //  so get them both then delete them.
+    // We may want to look at a way to make this cleaner.
+    auto skins = getAllSkins();
+    auto nodes = getAllNodes();
+    GLTFObjectDeleter(std::move(skins));
+    GLTFObjectDeleter(std::move(nodes));
 
     GLTFObjectDeleter(std::move(animations));
     GLTFObjectDeleter(std::move(scenes));

--- a/GLTF/src/GLTFAsset.cpp
+++ b/GLTF/src/GLTFAsset.cpp
@@ -417,7 +417,7 @@ std::vector<GLTF::BufferView*> GLTF::Asset::getAllBufferViews()
     }
     for (GLTF::Image* image : getAllImages()) {
         GLTF::BufferView* bufferView = image->bufferView;
-        if (uniqueBufferViewss.find(bufferView) == uniqueBufferViewss.end()) {
+        if (bufferView && (uniqueBufferViewss.find(bufferView) == uniqueBufferViewss.end())) {
             bufferViews.push_back(bufferView);
             uniqueBufferViewss.insert(bufferView);
         }

--- a/GLTF/src/GLTFAsset.cpp
+++ b/GLTF/src/GLTFAsset.cpp
@@ -26,6 +26,9 @@ GLTF::Asset::~Asset() {
     delete metadata;
     delete globalSampler;
 
+    GLTFObjectDeleter(getAllBuffers());
+    GLTFObjectDeleter(getAllBufferViews());
+
     GLTFObjectDeleter(getAllImages());
     GLTFObjectDeleter(getAllTextures());
 
@@ -34,9 +37,6 @@ GLTF::Asset::~Asset() {
     GLTFObjectDeleter(getAllTechniques());
 
     GLTFObjectDeleter(getAllMaterials());
-
-    GLTFObjectDeleter(getAllBuffers());
-    GLTFObjectDeleter(getAllBufferViews());
 
     GLTFObjectDeleter(getAllAccessors());
 
@@ -415,6 +415,13 @@ std::vector<GLTF::BufferView*> GLTF::Asset::getAllBufferViews()
             uniqueBufferViewss.insert(bufferView);
         }
     }
+    for (GLTF::Image* image : getAllImages()) {
+        GLTF::BufferView* bufferView = image->bufferView;
+        if (uniqueBufferViewss.find(bufferView) == uniqueBufferViewss.end()) {
+            bufferViews.push_back(bufferView);
+            uniqueBufferViewss.insert(bufferView);
+        }
+    }
     return bufferViews;
 }
 
@@ -451,8 +458,7 @@ std::vector<GLTF::MaterialCommon::Light*> GLTF::Asset::getAllLights()
 {
     std::vector<GLTF::MaterialCommon::Light*> lights;
     std::set<GLTF::MaterialCommon::Light*> uniqueLights;
-    for (GLTF::Node* node : getAllNodes()) {
-        GLTF::MaterialCommon::Light* light = node->light;
+    for (GLTF::MaterialCommon::Light* light : _ambientLights) {
         if (uniqueLights.find(light) == uniqueLights.end()) {
             lights.push_back(light);
             uniqueLights.insert(light);

--- a/GLTF/src/GLTFAsset.cpp
+++ b/GLTF/src/GLTFAsset.cpp
@@ -9,7 +9,7 @@
 #include "rapidjson/writer.h"
 
 template<typename T>
-void GLTFObjectDeleter(std::vector<T*>& v) {
+void GLTFObjectDeleter(std::vector<T*>&& v) {
     std::for_each(v.begin(), v.end(), std::default_delete<T>());
     v.clear();
 }
@@ -49,8 +49,8 @@ GLTF::Asset::~Asset() {
 
     GLTFObjectDeleter(getAllNodes());
 
-    GLTFObjectDeleter(animations);
-    GLTFObjectDeleter(scenes);
+    GLTFObjectDeleter(std::move(animations));
+    GLTFObjectDeleter(std::move(scenes));
 }
 
 void GLTF::Asset::Metadata::writeJSON(void* writer, GLTF::Options* options) {

--- a/GLTF/src/GLTFAsset.cpp
+++ b/GLTF/src/GLTFAsset.cpp
@@ -4,6 +4,7 @@
 #include <functional>
 #include <map>
 #include <set>
+#include <memory>
 
 #include "rapidjson/stringbuffer.h"
 #include "rapidjson/writer.h"

--- a/GLTF/src/GLTFAsset.cpp
+++ b/GLTF/src/GLTFAsset.cpp
@@ -701,7 +701,7 @@ GLTF::BufferView* packAccessorsForTargetByteStride(std::vector<GLTF::Accessor*> 
 	GLTF::BufferView* bufferView = new GLTF::BufferView(bufferData, byteLength, target);
 	for (GLTF::Accessor* accessor : accessors) {
 		size_t byteOffset = byteOffsets[accessor];
-		auto packedAccessor = std::make_unique<GLTF::Accessor>(accessor->type, accessor->componentType, byteOffset, accessor->count, bufferView);
+		auto packedAccessor = std::unique_ptr<GLTF::Accessor>(new GLTF::Accessor(accessor->type, accessor->componentType, byteOffset, accessor->count, bufferView));
 		int numberOfComponents = accessor->getNumberOfComponents();
 		std::vector<float> component(numberOfComponents);
 		for (int i = 0; i < accessor->count; i++) {

--- a/GLTF/src/GLTFBuffer.cpp
+++ b/GLTF/src/GLTFBuffer.cpp
@@ -9,6 +9,10 @@ GLTF::Buffer::Buffer(unsigned char* data, int dataLength) {
 	this->byteLength = dataLength;
 }
 
+GLTF::Buffer::~Buffer() {
+    delete[] this->data;
+}
+
 std::string GLTF::Buffer::typeName() {
 	return "buffer";
 }

--- a/GLTF/src/GLTFBuffer.cpp
+++ b/GLTF/src/GLTFBuffer.cpp
@@ -10,7 +10,7 @@ GLTF::Buffer::Buffer(unsigned char* data, int dataLength) {
 }
 
 GLTF::Buffer::~Buffer() {
-    delete[] this->data;
+    free(this->data);
 }
 
 std::string GLTF::Buffer::typeName() {

--- a/GLTF/src/GLTFImage.cpp
+++ b/GLTF/src/GLTFImage.cpp
@@ -32,6 +32,8 @@ GLTF::Image::~Image() {
 	if (!cacheKey.empty()) {
 		_imageCache.erase(cacheKey);
 	}
+
+    delete[] this->data;
 }
 
 GLTF::Image* GLTF::Image::load(std::string imagePath) {

--- a/GLTF/src/GLTFImage.cpp
+++ b/GLTF/src/GLTFImage.cpp
@@ -33,7 +33,7 @@ GLTF::Image::~Image() {
 		_imageCache.erase(cacheKey);
 	}
 
-    delete[] this->data;
+	free(this->data);
 }
 
 GLTF::Image* GLTF::Image::load(std::string imagePath) {
@@ -69,7 +69,7 @@ GLTF::Image* GLTF::Image::load(std::string imagePath) {
 		fclose(file);
 		file = fopen(imagePath.c_str(), "rb");
 		unsigned char* buffer = (unsigned char*)malloc(size);
-		int bytesRead = fread(buffer, sizeof(unsigned char), size, file);
+		size_t bytesRead = fread(buffer, sizeof(unsigned char), size, file);
 		fclose(file);
 		image = new GLTF::Image(fileName, imagePath, buffer, bytesRead, fileExtension);
 	}

--- a/GLTF/src/GLTFMaterial.cpp
+++ b/GLTF/src/GLTFMaterial.cpp
@@ -9,6 +9,21 @@ GLTF::Material::Material() {
 	this->type = GLTF::Material::MATERIAL;
 }
 
+GLTF::Material::~Material()
+{
+    if (values) {
+        delete[] values->ambient;
+        delete[] values->diffuse;
+        delete[] values->emission;
+        delete[] values->specular;
+        delete[] values->shininess;
+        delete[] values->transparency;
+
+        delete values;
+        values = nullptr;
+    }
+}
+
 bool GLTF::Material::hasTexture() {
 	return this->values->diffuseTexture != NULL;
 }
@@ -155,6 +170,14 @@ void GLTF::MaterialPBR::Texture::writeJSON(void* writer, GLTF::Options* options)
 	GLTF::Object::writeJSON(writer, options);
 }
 
+GLTF::MaterialPBR::MetallicRoughness::~MetallicRoughness()
+{
+    delete baseColorTexture;
+    delete metallicRoughnessTexture;
+
+    // baseColorFactor is stored in this->values
+}
+
 void GLTF::MaterialPBR::MetallicRoughness::writeJSON(void* writer, GLTF::Options* options) {
 	rapidjson::Writer<rapidjson::StringBuffer>* jsonWriter = (rapidjson::Writer<rapidjson::StringBuffer>*)writer;
 	if (baseColorFactor) {
@@ -186,6 +209,14 @@ void GLTF::MaterialPBR::MetallicRoughness::writeJSON(void* writer, GLTF::Options
 		jsonWriter->EndObject();
 	}
 	GLTF::Object::writeJSON(writer, options);
+}
+
+GLTF::MaterialPBR::SpecularGlossiness::~SpecularGlossiness()
+{
+    delete diffuseTexture;
+    delete specularGlossinessTexture;
+
+    // diffuseFactor, specularFactor, glossinessFactor are stored in this->values
 }
 
 void GLTF::MaterialPBR::SpecularGlossiness::writeJSON(void* writer, GLTF::Options* options) {
@@ -332,7 +363,6 @@ void GLTF::MaterialCommon::Light::writeJSON(void* writer, GLTF::Options* options
 }
 
 GLTF::MaterialCommon::MaterialCommon() {
-	this->values = new GLTF::Material::Values();
 	this->type = GLTF::Material::MATERIAL_COMMON;
 }
 
@@ -850,6 +880,18 @@ std::string GLTF::MaterialCommon::getTechniqueKey(GLTF::Options* options) {
 	return id;
 }
 
+GLTF::MaterialPBR::~MaterialPBR()
+{
+    delete metallicRoughness;
+    delete specularGlossiness;
+
+    delete normalTexture;
+    delete occlusionTexture;
+    delete emissiveTexture;
+
+    // emissiveFactor is stored in this->values
+}
+
 GLTF::MaterialPBR::MaterialPBR() {
 	this->type = GLTF::Material::PBR_METALLIC_ROUGHNESS;
 	this->metallicRoughness = new GLTF::MaterialPBR::MetallicRoughness();
@@ -879,19 +921,19 @@ GLTF::MaterialPBR* GLTF::MaterialCommon::getMaterialPBR(GLTF::Options* options) 
 		}
 	}
 
-	if (values->emission) {
-		if (values->emission[3] < 1.0) {
-			hasTransparency = true;
-		}
-		material->emissiveFactor = values->emission;
-	}
 	if (values->emissionTexture) {
 		GLTF::MaterialPBR::Texture* texture = new GLTF::MaterialPBR::Texture();
 		texture->texCoord = values->emissionTexCoord;
 		texture->texture = values->emissionTexture;
 		material->emissiveTexture = texture;
-		material->emissiveFactor = new float[3]{ 1.0, 1.0, 1.0 };
+        values->emission = new float[3]{ 1.0, 1.0, 1.0 };
 	}
+    if (values->emission) {
+        if (values->emission[3] < 1.0) {
+            hasTransparency = true;
+        }
+        material->emissiveFactor = values->emission;
+    }
 
 	if (values->ambientTexture) {
 		GLTF::MaterialPBR::Texture* texture = new GLTF::MaterialPBR::Texture();
@@ -914,12 +956,10 @@ GLTF::MaterialPBR* GLTF::MaterialCommon::getMaterialPBR(GLTF::Options* options) 
 			material->specularGlossiness->specularGlossinessTexture = texture;
 		}
 		if (values->shininess) {
-			if (values->shininess[0] < 1.0) {
-				material->specularGlossiness->glossinessFactor = values->shininess;
+			if (values->shininess[0] > 1.0) {
+                values->shininess = new float[1] {1.0};
 			}
-			else {
-				material->specularGlossiness->glossinessFactor = new float[1] {1.0};
-			}
+            material->specularGlossiness->glossinessFactor = values->shininess;
 		}
 	}
 

--- a/GLTF/src/GLTFMaterial.cpp
+++ b/GLTF/src/GLTFMaterial.cpp
@@ -888,12 +888,7 @@ GLTF::MaterialPBR::~MaterialPBR()
     delete normalTexture;
     delete occlusionTexture;
     delete emissiveTexture;
-
-    // emissiveFactor may be a copy of values->emission,
-    //  so only delete it if it is not.
-    if (emissiveFactor != values->emission) {
-        delete emissiveFactor;
-    }
+    delete emissiveFactor;
 }
 
 GLTF::MaterialPBR::MaterialPBR() {
@@ -929,7 +924,7 @@ GLTF::MaterialPBR* GLTF::MaterialCommon::getMaterialPBR(GLTF::Options* options) 
         if (values->emission[3] < 1.0) {
             hasTransparency = true;
         }
-        material->emissiveFactor = values->emission;
+        material->emissiveFactor = new float[3]{ values->emission[0], values->emission[1], values->emission[2] };
     }
 	if (values->emissionTexture) {
 		GLTF::MaterialPBR::Texture* texture = new GLTF::MaterialPBR::Texture();

--- a/GLTF/src/GLTFMaterial.cpp
+++ b/GLTF/src/GLTFMaterial.cpp
@@ -926,7 +926,7 @@ GLTF::MaterialPBR* GLTF::MaterialCommon::getMaterialPBR(GLTF::Options* options) 
 		texture->texCoord = values->emissionTexCoord;
 		texture->texture = values->emissionTexture;
 		material->emissiveTexture = texture;
-        values->emission = new float[3]{ 1.0, 1.0, 1.0 };
+        values->emission = new float[4]{ 1.0, 1.0, 1.0, 1.0 };
 	}
     if (values->emission) {
         if (values->emission[3] < 1.0) {
@@ -957,7 +957,7 @@ GLTF::MaterialPBR* GLTF::MaterialCommon::getMaterialPBR(GLTF::Options* options) 
 		}
 		if (values->shininess) {
 			if (values->shininess[0] > 1.0) {
-                values->shininess = new float[1] {1.0};
+                values->shininess[0] = 1.0;
 			}
             material->specularGlossiness->glossinessFactor = values->shininess;
 		}

--- a/GLTF/src/GLTFMaterial.cpp
+++ b/GLTF/src/GLTFMaterial.cpp
@@ -889,7 +889,11 @@ GLTF::MaterialPBR::~MaterialPBR()
     delete occlusionTexture;
     delete emissiveTexture;
 
-    // emissiveFactor is stored in this->values
+    // emissiveFactor may be a copy of values->emission,
+    //  so only delete it if it is not.
+    if (emissiveFactor != values->emission) {
+        delete emissiveFactor;
+    }
 }
 
 GLTF::MaterialPBR::MaterialPBR() {
@@ -921,19 +925,19 @@ GLTF::MaterialPBR* GLTF::MaterialCommon::getMaterialPBR(GLTF::Options* options) 
 		}
 	}
 
-	if (values->emissionTexture) {
-		GLTF::MaterialPBR::Texture* texture = new GLTF::MaterialPBR::Texture();
-		texture->texCoord = values->emissionTexCoord;
-		texture->texture = values->emissionTexture;
-		material->emissiveTexture = texture;
-        values->emission = new float[4]{ 1.0, 1.0, 1.0, 1.0 };
-	}
     if (values->emission) {
         if (values->emission[3] < 1.0) {
             hasTransparency = true;
         }
         material->emissiveFactor = values->emission;
     }
+	if (values->emissionTexture) {
+		GLTF::MaterialPBR::Texture* texture = new GLTF::MaterialPBR::Texture();
+		texture->texCoord = values->emissionTexCoord;
+		texture->texture = values->emissionTexture;
+		material->emissiveTexture = texture;
+		material->emissiveFactor = new float[3]{ 1.0, 1.0, 1.0 };
+	}
 
 	if (values->ambientTexture) {
 		GLTF::MaterialPBR::Texture* texture = new GLTF::MaterialPBR::Texture();

--- a/GLTF/src/GLTFNode.cpp
+++ b/GLTF/src/GLTFNode.cpp
@@ -222,6 +222,10 @@ GLTF::Node::TransformMatrix* GLTF::Node::TransformTRS::getTransformMatrix() {
 	return result;
 }
 
+GLTF::Node::~Node() {
+    delete transform;
+}
+
 std::string GLTF::Node::typeName() {
 	return "node";
 }

--- a/GLTF/src/GLTFObject.cpp
+++ b/GLTF/src/GLTFObject.cpp
@@ -4,6 +4,15 @@
 #include "rapidjson/stringbuffer.h"
 #include "rapidjson/writer.h"
 
+GLTF::Object::~Object() {
+    for (auto& kv : extensions) {
+        delete kv.second;
+    }
+    for (auto& kv : extras) {
+        delete kv.second;
+    }
+}
+
 std::string GLTF::Object::getStringId() {
 	if (stringId == "") {
 		return typeName() + "_" + std::to_string(id);

--- a/GLTF/src/GLTFPrimitive.cpp
+++ b/GLTF/src/GLTFPrimitive.cpp
@@ -3,6 +3,8 @@
 #include "rapidjson/stringbuffer.h"
 #include "rapidjson/writer.h"
 
+#include <algorithm>
+
 GLTF::Primitive::~Primitive() {
     std::for_each(targets.begin(), targets.end(), std::default_delete<Target>());
 }

--- a/GLTF/src/GLTFPrimitive.cpp
+++ b/GLTF/src/GLTFPrimitive.cpp
@@ -3,6 +3,10 @@
 #include "rapidjson/stringbuffer.h"
 #include "rapidjson/writer.h"
 
+GLTF::Primitive::~Primitive() {
+    std::for_each(targets.begin(), targets.end(), std::default_delete<Target>());
+}
+
 GLTF::Object* GLTF::Primitive::clone(GLTF::Object* clone) {
 	GLTF::Primitive* primitive = dynamic_cast<GLTF::Primitive*>(clone);
 	if (primitive != NULL) {

--- a/GLTF/src/GLTFTechnique.cpp
+++ b/GLTF/src/GLTFTechnique.cpp
@@ -3,6 +3,12 @@
 #include "rapidjson/stringbuffer.h"
 #include "rapidjson/writer.h"
 
+GLTF::Technique::~Technique() {
+    for (auto& kv : parameters) {
+        delete kv.second;
+    }
+}
+
 std::string GLTF::Technique::typeName() {
 	return "technique";
 }

--- a/dependencies/OpenCOLLADA/modules/COLLADASaxFrameworkLoader/CMakeLists.txt
+++ b/dependencies/OpenCOLLADA/modules/COLLADASaxFrameworkLoader/CMakeLists.txt
@@ -41,14 +41,22 @@ include_directories(${BASE_PATH}/GeneratedSaxParser/include)
 add_subdirectory(GeneratedSaxParser)
 
 # LibXML
-include_directories(${BASE_PATH}/Externals/LibXML/include)
+if(NOT LIBXML2_FOUND)
+  include_directories(${BASE_PATH}/Externals/LibXML/include)
+else()
+  include_directories(${LIBXML2_INCLUDE_DIR})
+endif()
 
 # expat
 include_directories(${BASE_PATH}/Externals/expat/lib)
 
 # pcre
-add_definitions(-DPCRE_STATIC)
-include_directories(${BASE_PATH}/Externals/pcre/include)
+if(NOT PCRE_FOUND)
+  add_definitions(-DPCRE_STATIC)
+  include_directories(${BASE_PATH}/Externals/pcre/include)
+else()
+  include_directories(${PCRE_INCLUDE_DIR})
+endif()
 
 add_library(${PROJECT_NAME} ${HEADERS} ${SOURCES} ${HEADERS_GENERATED14} ${SOURCES_GENERATED14} ${HEADERS_GENERATED15} ${SOURCES_GENERATED15})
 target_link_libraries(${PROJECT_NAME} COLLADAFramework GeneratedSaxParser)

--- a/dependencies/OpenCOLLADA/modules/COLLADASaxFrameworkLoader/COLLADAFramework/COLLADABaseUtils/CMakeLists.txt
+++ b/dependencies/OpenCOLLADA/modules/COLLADASaxFrameworkLoader/COLLADAFramework/COLLADABaseUtils/CMakeLists.txt
@@ -22,9 +22,13 @@ file(GLOB UTF_HEADERS "${BASE_PATH}/Externals/UTF/include/*.h")
 file(GLOB UTF_SOURCES "${BASE_PATH}/Externals/UTF/src/*.c")
 
 # pcre
-add_definitions(-DPCRE_STATIC)
-include_directories(${BASE_PATH}/Externals/pcre/include)
-add_subdirectory(pcre)
+if(NOT PCRE_FOUND)
+  add_definitions(-DPCRE_STATIC)
+  include_directories(${BASE_PATH}/Externals/pcre/include)
+  add_subdirectory(pcre)
+else()
+  include_directories(${PCRE_INCLUDE_DIR})
+endif()
 
 add_library(${PROJECT_NAME} ${HEADERS} ${SOURCES} ${MATH_HEADERS} ${MATH_SOURCES} ${UTF_HEADERS} ${UTF_SOURCES})
 target_link_libraries(${PROJECT_NAME} pcre)

--- a/dependencies/OpenCOLLADA/modules/COLLADASaxFrameworkLoader/GeneratedSaxParser/CMakeLists.txt
+++ b/dependencies/OpenCOLLADA/modules/COLLADASaxFrameworkLoader/GeneratedSaxParser/CMakeLists.txt
@@ -16,8 +16,12 @@ include_directories(${BASE_PATH}/Externals/expat/lib)
 add_subdirectory(expat)
 
 # LibXML
-include_directories(${BASE_PATH}/Externals/LibXML/include)
-add_subdirectory(LibXML)
+if(NOT LIBXML2_FOUND)
+  include_directories(${BASE_PATH}/Externals/LibXML/include)
+  add_subdirectory(LibXML)
+else()
+  include_directories(${LIBXML2_INCLUDE_DIR})
+endif()
 
 add_library(${PROJECT_NAME} ${HEADERS} ${SOURCES})
 target_link_libraries(${PROJECT_NAME} expat LibXML)

--- a/src/COLLADA2GLTFWriter.cpp
+++ b/src/COLLADA2GLTFWriter.cpp
@@ -315,17 +315,21 @@ bool COLLADA2GLTF::Writer::writeNodeToGroup(std::vector<GLTF::Node*>* group, con
 	const COLLADAFW::InstanceLightPointerArray& instanceLights = colladaNode->getInstanceLights();
 	for (size_t i = 0; i < instanceLights.getCount(); i++) {
 		COLLADAFW::InstanceLight* instanceLight = instanceLights[i];
-		GLTF::MaterialCommon::Light* light = _lightInstances[instanceLight->getInstanciatedObjectId()];
-		node->light = light;
-		light->node = node;
+        auto it = _lightInstances.find(instanceLight->getInstanciatedObjectId());
+        if (it != _lightInstances.end()) {
+            node->light = it->second;
+            it->second->node = node;
+        }
 	}
 
 	// Instance cameras
 	const COLLADAFW::InstanceCameraPointerArray& instanceCameras = colladaNode->getInstanceCameras();
 	for (size_t i = 0; i < instanceCameras.getCount(); i++) {
 		COLLADAFW::InstanceCamera* instanceCamera = instanceCameras[i];
-		GLTF::Camera* camera = _cameraInstances[instanceCamera->getInstanciatedObjectId()];
-		node->camera = camera;
+        auto it = _cameraInstances.find(instanceCamera->getInstanciatedObjectId());
+        if (it != _cameraInstances.end()) {
+            node->camera = it->second;
+        }
 	}
 
 	// Identify and map unbound skeleton nodes


### PR DESCRIPTION
I tried to keep it as simple as possible. This has a few changes
1. `~Asset` now cleans up all of the top level objects. I believe I do it in the correct order.
2. All the secondary objects get deleted with its parent (eg. `Animation::Channel`, `Primitive::Target`, etc)
3. Since we are cleaning up the data pointers for `Image` and `Buffer`, I made them use the `malloc`/`realloc`/`free` everywhere. It was like that most places but there were a few `new unsigned char[]`'s which isn't recommended (although with a byte array was probably fine). I went this way strictly because I had to change less code, so maybe we want to clean that up with a more modern technique at some point.
4. I ran into a bunch of models that didn't have lights/cameras but had instances of them. It looks like the Modo exporter did this in error. Just added a little safety to ignore missing references to make sure they don't crash.

Let me know what you guys think @Ziriax @lasalvavida 