### PR TITLE
Need to clone transforms because they are owned by a node

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,9 @@ Change Log
 * Added support for exporting COLLADA animation clips as groups [#227](https://github.com/KhronosGroup/COLLADA2GLTF/pull/227)
 * Clean up glTF tree when the asset is freed [#229](https://github.com/KhronosGroup/COLLADA2GLTF/issues/229)
 
+##### Fixes :wrench:
+* Library nodes should only be written as part of a scene [#236](https://github.com/KhronosGroup/COLLADA2GLTF/issues/236)
+
 ### v2.1.4 - 2018-08-29
 
 ##### Additions :tada:

--- a/GLTF/include/GLTFNode.h
+++ b/GLTF/include/GLTFNode.h
@@ -20,6 +20,8 @@ namespace GLTF {
 			};
 
 			Type type;
+
+			virtual Transform* clone() = 0;
 		};
 
 		class TransformTRS;
@@ -39,6 +41,8 @@ namespace GLTF {
 			bool isIdentity();
 			void getTransformTRS(TransformTRS* out);
 			TransformTRS* getTransformTRS();
+
+			Transform* clone();
 		};
 
 		class TransformTRS : public Transform {
@@ -52,9 +56,11 @@ namespace GLTF {
 			bool isIdentityRotation();
 			bool isIdentityScale();
 			TransformMatrix* getTransformMatrix();
+
+			Transform* clone();
 		};
 
-        ~Node();
+		~Node();
 
 		GLTF::Camera* camera = NULL;
 		std::vector<GLTF::Node*> children;

--- a/GLTF/src/GLTFNode.cpp
+++ b/GLTF/src/GLTFNode.cpp
@@ -111,6 +111,13 @@ GLTF::Node::TransformTRS* GLTF::Node::TransformMatrix::getTransformTRS() {
 	return trs;
 }
 
+GLTF::Node::Transform* GLTF::Node::TransformMatrix::clone()
+{
+    auto result = new TransformMatrix();
+    memcpy(result->matrix, matrix, sizeof(float) * 16);
+    return result;
+}
+
 const int rotationMatrixNext[3] = { 1, 2, 0 };
 void GLTF::Node::TransformMatrix::getTransformTRS(GLTF::Node::TransformTRS* trs) {
 	// get translation
@@ -222,6 +229,17 @@ GLTF::Node::TransformMatrix* GLTF::Node::TransformTRS::getTransformMatrix() {
 	return result;
 }
 
+GLTF::Node::Transform* GLTF::Node::TransformTRS::clone()
+{
+    auto result = new TransformTRS();
+
+    memcpy(result->translation, translation, sizeof(float) * 3);
+    memcpy(result->rotation, rotation, sizeof(float) * 4);
+    memcpy(result->scale, scale, sizeof(float) * 3);
+
+    return result;
+}
+
 GLTF::Node::~Node() {
     delete transform;
 }
@@ -243,7 +261,7 @@ GLTF::Object* GLTF::Node::clone(GLTF::Object* clone) {
 		node->jointName = jointName;
 		node->mesh = mesh;
 		node->light = light;
-		node->transform = transform;
+		node->transform = transform->clone();
 		GLTF::Object::clone(clone);
 	}
 	return node;

--- a/src/COLLADA2GLTFWriter.cpp
+++ b/src/COLLADA2GLTFWriter.cpp
@@ -521,7 +521,7 @@ bool COLLADA2GLTF::Writer::writeLibraryNodes(const COLLADAFW::LibraryNodes* libr
     //  in the actual model. Instead we add to this temporary group that stores the original and
     //  instance_nodes will be resolved with a clone so this group can be safely freed afterwards.
     std::vector<GLTF::Node*> temporaryGroup;
-    bool result = this->writeNodesToGroup(nullptr, libraryNodes->getNodes());
+    bool result = this->writeNodesToGroup(&temporaryGroup, libraryNodes->getNodes());
     RecursiveNodeDeleter(temporaryGroup);
 
     return result;

--- a/src/COLLADA2GLTFWriter.cpp
+++ b/src/COLLADA2GLTFWriter.cpp
@@ -62,10 +62,10 @@ bool COLLADA2GLTF::Writer::writeGlobalAsset(const COLLADAFW::FileInfo* asset) {
 			}
 
 			if (tokens.size() > 0) {
-				// Get major version
+				// Get major version (or lack of)
 				token = tokens[tokens.size() - 1];
 				try {
-					if (std::stoi(token) < 8) {
+					if (token == "SketchUp" || (std::stoi(token) < 8)) {
 						_options->invertTransparency = true;
 					}
 				} catch (const std::invalid_argument& e) {

--- a/test/src/COLLADA2GLTFWriterTest.cpp
+++ b/test/src/COLLADA2GLTFWriterTest.cpp
@@ -17,40 +17,40 @@ COLLADA2GLTFWriterTest::~COLLADA2GLTFWriterTest() {
 	delete asset;
 }
 
-TEST_F(COLLADA2GLTFWriterTest, WriteLibraryNodes_SingleNode) {
-	COLLADAFW::LibraryNodes* nodes = new COLLADAFW::LibraryNodes();
+TEST_F(COLLADA2GLTFWriterTest, WriteVisualScene_SingleNode) {
+	COLLADAFW::VisualScene* visualScene = new COLLADAFW::VisualScene(COLLADAFW::UniqueId(COLLADAFW::COLLADA_TYPE::VISUAL_SCENE, 0, 0));
 	COLLADAFW::Node* node = new COLLADAFW::Node(COLLADAFW::UniqueId(COLLADAFW::COLLADA_TYPE::NODE, 0, 0));
-	nodes->getNodes().append(node);
-	this->writer->writeLibraryNodes(nodes);
+	visualScene->getRootNodes().append(node);
+	this->writer->writeVisualScene(visualScene);
 	GLTF::Scene* scene = this->asset->getDefaultScene();
 	ASSERT_TRUE(scene != NULL);
 	std::vector<GLTF::Node*> sceneNodes = scene->nodes;
 	EXPECT_EQ(sceneNodes.size(), 1);
 }
 
-TEST_F(COLLADA2GLTFWriterTest, WriteLibraryNodes_MultipleNodes) {
-	COLLADAFW::LibraryNodes* nodes = new COLLADAFW::LibraryNodes();
+TEST_F(COLLADA2GLTFWriterTest, WriteVisualScene_MultipleNodes) {
+	COLLADAFW::VisualScene* visualScene = new COLLADAFW::VisualScene(COLLADAFW::UniqueId(COLLADAFW::COLLADA_TYPE::VISUAL_SCENE, 0, 0));
 	COLLADAFW::Node* nodeOne = new COLLADAFW::Node(COLLADAFW::UniqueId(COLLADAFW::COLLADA_TYPE::NODE, 0, 0));
 	COLLADAFW::Node* nodeTwo = new COLLADAFW::Node(COLLADAFW::UniqueId(COLLADAFW::COLLADA_TYPE::NODE, 1, 0));
-	nodes->getNodes().append(nodeOne);
-	nodes->getNodes().append(nodeTwo);
-	this->writer->writeLibraryNodes(nodes);
+	visualScene->getRootNodes().append(nodeOne);
+	visualScene->getRootNodes().append(nodeTwo);
+	this->writer->writeVisualScene(visualScene);
 	GLTF::Scene* scene = this->asset->getDefaultScene();
 	ASSERT_TRUE(scene != NULL);
 	std::vector<GLTF::Node*> sceneNodes = scene->nodes;
 	EXPECT_EQ(sceneNodes.size(), 2);
 }
 
-TEST_F(COLLADA2GLTFWriterTest, WriteLibraryNodes_MeshDoesNotExist) {
-	COLLADAFW::LibraryNodes* nodes = new COLLADAFW::LibraryNodes();
+TEST_F(COLLADA2GLTFWriterTest, WriteVisualScene_MeshDoesNotExist) {
+	COLLADAFW::VisualScene* visualScene = new COLLADAFW::VisualScene(COLLADAFW::UniqueId(COLLADAFW::COLLADA_TYPE::VISUAL_SCENE, 0, 0));
 	COLLADAFW::Node* node = new COLLADAFW::Node(COLLADAFW::UniqueId(COLLADAFW::COLLADA_TYPE::NODE, 0, 0));
 	COLLADAFW::InstanceGeometry* instanceGeometry = new COLLADAFW::InstanceGeometry(
 		COLLADAFW::UniqueId(COLLADAFW::COLLADA_TYPE::MESH, 0, 0),
 		COLLADAFW::UniqueId(COLLADAFW::COLLADA_TYPE::MESH, 1, 0)
 	);
 	node->getInstanceGeometries().append(instanceGeometry);
-	nodes->getNodes().append(node);
-	this->writer->writeLibraryNodes(nodes);
+	visualScene->getRootNodes().append(node);
+	this->writer->writeVisualScene(visualScene);
 	GLTF::Scene* scene = this->asset->getDefaultScene();
 	ASSERT_TRUE(scene != NULL);
 	std::vector<GLTF::Node*> sceneNodes = scene->nodes;
@@ -60,8 +60,8 @@ TEST_F(COLLADA2GLTFWriterTest, WriteLibraryNodes_MeshDoesNotExist) {
 	ASSERT_TRUE(mesh == NULL);
 }
 
-TEST_F(COLLADA2GLTFWriterTest, WriteLibraryNodes_MeshDoesExist) {
-	COLLADAFW::LibraryNodes* nodes = new COLLADAFW::LibraryNodes();
+TEST_F(COLLADA2GLTFWriterTest, WriteVisualScene_MeshDoesExist) {
+	COLLADAFW::VisualScene* visualScene = new COLLADAFW::VisualScene(COLLADAFW::UniqueId(COLLADAFW::COLLADA_TYPE::VISUAL_SCENE, 0, 0));
 	COLLADAFW::Node* node = new COLLADAFW::Node(COLLADAFW::UniqueId(COLLADAFW::COLLADA_TYPE::NODE, 0, 0));
 	COLLADAFW::InstanceGeometry* instanceGeometry = new COLLADAFW::InstanceGeometry(
 		COLLADAFW::UniqueId(COLLADAFW::COLLADA_TYPE::MESH, 1, 0),
@@ -70,8 +70,8 @@ TEST_F(COLLADA2GLTFWriterTest, WriteLibraryNodes_MeshDoesExist) {
 	COLLADAFW::Geometry* geometry = new COLLADAFW::Mesh(COLLADAFW::UniqueId(COLLADAFW::COLLADA_TYPE::MESH, 0, 0));
 	this->writer->writeGeometry(geometry);
 	node->getInstanceGeometries().append(instanceGeometry);
-	nodes->getNodes().append(node);
-	this->writer->writeLibraryNodes(nodes);
+	visualScene->getRootNodes().append(node);
+	this->writer->writeVisualScene(visualScene);
 	GLTF::Scene* scene = this->asset->getDefaultScene();
 	ASSERT_TRUE(scene != NULL);
 	std::vector<GLTF::Node*> sceneNodes = scene->nodes;


### PR DESCRIPTION
All the other members of a node are references that are cleaned up later in `~Asset` except for the `transform`. If we clone a node, then the transform will be deleted twice. This clones the transform to prevent that.