### PR TITLE
Fixed issues where there were multiple levels of instances

### DIFF
--- a/GLTF/include/GLTFNode.h
+++ b/GLTF/include/GLTFNode.h
@@ -71,8 +71,8 @@ namespace GLTF {
 
 		Transform* transform = NULL;
 
-        // Special implementation that takes a predicate so mappings can be updated for all children
-        GLTF::Object* clone(GLTF::Node* node, std::function<void(GLTF::Node*, GLTF::Node*)>& predicate);
+		// Special implementation that takes a predicate so mappings can be updated for all children
+		GLTF::Object* clone(GLTF::Node* node, std::function<void(GLTF::Node*, GLTF::Node*)>& predicate);
 
 		virtual std::string typeName();
 		virtual GLTF::Object* clone(GLTF::Object* clone);

--- a/GLTF/include/GLTFNode.h
+++ b/GLTF/include/GLTFNode.h
@@ -72,7 +72,7 @@ namespace GLTF {
 		Transform* transform = NULL;
 
         // Special implementation that takes a predicate so mappings can be updated for all children
-        GLTF::Object* GLTF::Node::clone(GLTF::Node* node, std::function<void(GLTF::Node*, GLTF::Node*)>& predicate);
+        GLTF::Object* clone(GLTF::Node* node, std::function<void(GLTF::Node*, GLTF::Node*)>& predicate);
 
 		virtual std::string typeName();
 		virtual GLTF::Object* clone(GLTF::Object* clone);

--- a/GLTF/include/GLTFNode.h
+++ b/GLTF/include/GLTFNode.h
@@ -71,6 +71,9 @@ namespace GLTF {
 
 		Transform* transform = NULL;
 
+        // Special implementation that takes a predicate so mappings can be updated for all children
+        GLTF::Object* GLTF::Node::clone(GLTF::Node* node, std::function<void(GLTF::Node*, GLTF::Node*)>& predicate);
+
 		virtual std::string typeName();
 		virtual GLTF::Object* clone(GLTF::Object* clone);
 		virtual void writeJSON(void* writer, GLTF::Options* options);

--- a/GLTF/src/GLTFNode.cpp
+++ b/GLTF/src/GLTFNode.cpp
@@ -249,12 +249,18 @@ std::string GLTF::Node::typeName() {
 }
 
 GLTF::Object* GLTF::Node::clone(GLTF::Object* clone) {
-	GLTF::Node* node = dynamic_cast<GLTF::Node*>(clone);
+    static std::function<void(GLTF::Node*, GLTF::Node*)> noop = [](GLTF::Node*, GLTF::Node*) { };
+
+    return this->clone(dynamic_cast<GLTF::Node*>(clone), noop);
+}
+
+GLTF::Object* GLTF::Node::clone(GLTF::Node* node, std::function<void(GLTF::Node*, GLTF::Node*)>& predicate) {
 	if (node != NULL) {
+        predicate(this, node);
 		node->camera = camera;
 		for (GLTF::Node* child : children) {
 			GLTF::Node* cloneChild = new GLTF::Node();
-			child->clone(cloneChild);
+			child->clone(cloneChild, predicate);
 			node->children.push_back(cloneChild);
 		}
 		node->skin = skin;
@@ -262,7 +268,7 @@ GLTF::Object* GLTF::Node::clone(GLTF::Object* clone) {
 		node->mesh = mesh;
 		node->light = light;
 		node->transform = transform->clone();
-		GLTF::Object::clone(clone);
+		GLTF::Object::clone(node);
 	}
 	return node;
 }

--- a/GLTF/src/GLTFNode.cpp
+++ b/GLTF/src/GLTFNode.cpp
@@ -249,14 +249,14 @@ std::string GLTF::Node::typeName() {
 }
 
 GLTF::Object* GLTF::Node::clone(GLTF::Object* clone) {
-    static std::function<void(GLTF::Node*, GLTF::Node*)> noop = [](GLTF::Node*, GLTF::Node*) { };
+	static std::function<void(GLTF::Node*, GLTF::Node*)> noop = [](GLTF::Node*, GLTF::Node*) { };
 
-    return this->clone(dynamic_cast<GLTF::Node*>(clone), noop);
+	return this->clone(dynamic_cast<GLTF::Node*>(clone), noop);
 }
 
 GLTF::Object* GLTF::Node::clone(GLTF::Node* node, std::function<void(GLTF::Node*, GLTF::Node*)>& predicate) {
 	if (node != NULL) {
-        predicate(this, node);
+		predicate(this, node);
 		node->camera = camera;
 		for (GLTF::Node* child : children) {
 			GLTF::Node* cloneChild = new GLTF::Node();

--- a/include/COLLADA2GLTFWriter.h
+++ b/include/COLLADA2GLTFWriter.h
@@ -48,7 +48,7 @@ namespace COLLADA2GLTF {
 
 		bool writeNodeToGroup(std::vector<GLTF::Node*>* group, const COLLADAFW::Node* node);
 		bool writeNodesToGroup(std::vector<GLTF::Node*>* group, const COLLADAFW::NodePointerArray& nodes);
-		void COLLADA2GLTF::Writer::nodeClonePredicate(GLTF::Node* node, GLTF::Node* clonedNode);
+		void nodeClonePredicate(GLTF::Node* node, GLTF::Node* clonedNode);
 		GLTF::Texture* fromColladaTexture(const COLLADAFW::EffectCommon* effectCommon, COLLADAFW::SamplerID samplerId);
 		GLTF::Texture* fromColladaTexture(const COLLADAFW::EffectCommon* effectCommon, COLLADAFW::Texture texture);
 

--- a/include/COLLADA2GLTFWriter.h
+++ b/include/COLLADA2GLTFWriter.h
@@ -27,6 +27,7 @@ namespace COLLADA2GLTF {
 		std::map<COLLADAFW::UniqueId, GLTF::Node*> _nodeInstances;
 		std::map<COLLADAFW::UniqueId, GLTF::Animation*> _animationInstances;
 		std::map<COLLADAFW::UniqueId, std::vector<GLTF::Node*>> _nodeInstanceTargets;
+		std::map<GLTF::Node*, std::vector<COLLADAFW::UniqueId>> _nodeInstanceTargetMapping;
 		std::map<COLLADAFW::UniqueId, std::map<int, std::set<GLTF::Primitive*>>> _meshMaterialPrimitiveMapping;
 		std::map<COLLADAFW::UniqueId, GLTF::MaterialCommon::Light*> _lightInstances;
 		std::map<COLLADAFW::UniqueId, std::map<GLTF::Primitive*, std::vector<unsigned int>>> _meshPositionMapping;
@@ -47,6 +48,7 @@ namespace COLLADA2GLTF {
 
 		bool writeNodeToGroup(std::vector<GLTF::Node*>* group, const COLLADAFW::Node* node);
 		bool writeNodesToGroup(std::vector<GLTF::Node*>* group, const COLLADAFW::NodePointerArray& nodes);
+		void COLLADA2GLTF::Writer::nodeClonePredicate(GLTF::Node* node, GLTF::Node* clonedNode);
 		GLTF::Texture* fromColladaTexture(const COLLADAFW::EffectCommon* effectCommon, COLLADAFW::SamplerID samplerId);
 		GLTF::Texture* fromColladaTexture(const COLLADAFW::EffectCommon* effectCommon, COLLADAFW::Texture texture);
 

--- a/src/COLLADA2GLTFWriter.cpp
+++ b/src/COLLADA2GLTFWriter.cpp
@@ -431,6 +431,9 @@ bool COLLADA2GLTF::Writer::writeNodeToGroup(std::vector<GLTF::Node*>* group, con
 	_nodes[id] = node;
 	_nodeInstances[colladaNodeId] = node;
 
+	std::function<void(GLTF::Node*, GLTF::Node*)> nodeClonePredicate =
+		std::bind(&Writer::nodeClonePredicate, this, std::placeholders::_1, std::placeholders::_2);
+
 	// Instance Nodes
 	const COLLADAFW::InstanceNodePointerArray& instanceNodes = colladaNode->getInstanceNodes();
 	size_t nodeCount = instanceNodes.getCount();
@@ -441,7 +444,7 @@ bool COLLADA2GLTF::Writer::writeNodeToGroup(std::vector<GLTF::Node*>* group, con
 		if (iter != _nodeInstances.end()) {
 			// Resolve the instance
 			GLTF::Node* cloneNode = new GLTF::Node();
-			iter->second->clone(cloneNode);
+			iter->second->clone(cloneNode, nodeClonePredicate);
 			node->children.push_back(cloneNode);
 		}
 		else {
@@ -451,6 +454,14 @@ bool COLLADA2GLTF::Writer::writeNodeToGroup(std::vector<GLTF::Node*>* group, con
 				_nodeInstanceTargets[instanceNodeId] = std::vector<GLTF::Node*>();
 			}
 			_nodeInstanceTargets[instanceNodeId].push_back(node);
+
+			// We need to keep track of nodes the depend on unresolved instances
+			// So that if they are cloned we can resolve to all the clones as well
+			std::map<GLTF::Node*, std::vector<COLLADAFW::UniqueId>>::iterator iter2 = _nodeInstanceTargetMapping.find(node);
+			if (iter2 == _nodeInstanceTargetMapping.end()) {
+				_nodeInstanceTargetMapping[node] = std::vector<COLLADAFW::UniqueId>();
+			}
+			_nodeInstanceTargetMapping[node].push_back(instanceNodeId);
 		}
 	}
 
@@ -468,12 +479,28 @@ bool COLLADA2GLTF::Writer::writeNodeToGroup(std::vector<GLTF::Node*>* group, con
 		std::vector<GLTF::Node*> instanceTargets = findNodeInstanceTargets->second;
 		for (GLTF::Node* instanceTarget : instanceTargets) {
 			GLTF::Node* cloneNode = new GLTF::Node();
-			node->clone(cloneNode);
+			node->clone(cloneNode, nodeClonePredicate);
 			instanceTarget->children.push_back(cloneNode);
 		}
 	}
 
 	return result;
+}
+
+void COLLADA2GLTF::Writer::nodeClonePredicate(GLTF::Node* node, GLTF::Node* clonedNode) {
+    _nodeInstanceTargetMapping[clonedNode] = std::vector<COLLADAFW::UniqueId>();
+
+    std::map<GLTF::Node*, std::vector<COLLADAFW::UniqueId>>::iterator iter = _nodeInstanceTargetMapping.find(node);
+    if (iter != _nodeInstanceTargetMapping.end()) {
+        std::vector<COLLADAFW::UniqueId>& instanceIds = iter->second;
+        for (COLLADAFW::UniqueId& instanceId : instanceIds) {
+            // In case this node is cloned, we need to track the instance_nodes it contains
+            _nodeInstanceTargetMapping[clonedNode].push_back(instanceId);
+
+            // This node now needs to be notified when a child instance_node is resolved
+            _nodeInstanceTargets[instanceId].push_back(clonedNode);
+        }
+    }
 }
 
 bool COLLADA2GLTF::Writer::writeNodesToGroup(std::vector<GLTF::Node*>* group, const COLLADAFW::NodePointerArray& nodes) {

--- a/src/COLLADA2GLTFWriter.cpp
+++ b/src/COLLADA2GLTFWriter.cpp
@@ -488,19 +488,19 @@ bool COLLADA2GLTF::Writer::writeNodeToGroup(std::vector<GLTF::Node*>* group, con
 }
 
 void COLLADA2GLTF::Writer::nodeClonePredicate(GLTF::Node* node, GLTF::Node* clonedNode) {
-    _nodeInstanceTargetMapping[clonedNode] = std::vector<COLLADAFW::UniqueId>();
+	_nodeInstanceTargetMapping[clonedNode] = std::vector<COLLADAFW::UniqueId>();
 
-    std::map<GLTF::Node*, std::vector<COLLADAFW::UniqueId>>::iterator iter = _nodeInstanceTargetMapping.find(node);
-    if (iter != _nodeInstanceTargetMapping.end()) {
-        std::vector<COLLADAFW::UniqueId>& instanceIds = iter->second;
-        for (COLLADAFW::UniqueId& instanceId : instanceIds) {
-            // In case this node is cloned, we need to track the instance_nodes it contains
-            _nodeInstanceTargetMapping[clonedNode].push_back(instanceId);
+	std::map<GLTF::Node*, std::vector<COLLADAFW::UniqueId>>::iterator iter = _nodeInstanceTargetMapping.find(node);
+	if (iter != _nodeInstanceTargetMapping.end()) {
+		std::vector<COLLADAFW::UniqueId>& instanceIds = iter->second;
+		for (COLLADAFW::UniqueId& instanceId : instanceIds) {
+			// In case this node is cloned, we need to track the instance_nodes it contains
+			_nodeInstanceTargetMapping[clonedNode].push_back(instanceId);
 
-            // This node now needs to be notified when a child instance_node is resolved
-            _nodeInstanceTargets[instanceId].push_back(clonedNode);
-        }
-    }
+			// This node now needs to be notified when a child instance_node is resolved
+			_nodeInstanceTargets[instanceId].push_back(clonedNode);
+		}
+	}
 }
 
 bool COLLADA2GLTF::Writer::writeNodesToGroup(std::vector<GLTF::Node*>* group, const COLLADAFW::NodePointerArray& nodes) {

--- a/test/src/COLLADA2GLTFWriterTest.cpp
+++ b/test/src/COLLADA2GLTFWriterTest.cpp
@@ -80,3 +80,52 @@ TEST_F(COLLADA2GLTFWriterTest, WriteVisualScene_MeshDoesExist) {
 	GLTF::Mesh* mesh = sceneNode->mesh;
 	ASSERT_TRUE(mesh != NULL);
 }
+
+TEST_F(COLLADA2GLTFWriterTest, WriteVisualScene_MultipleLevelsOfInstanceNodes) {
+	COLLADAFW::VisualScene* visualScene = new COLLADAFW::VisualScene(COLLADAFW::UniqueId(COLLADAFW::COLLADA_TYPE::VISUAL_SCENE, 0, 0));
+
+	// Create 2 root nodes
+	COLLADAFW::Node* vsNode1 = new COLLADAFW::Node(COLLADAFW::UniqueId(COLLADAFW::COLLADA_TYPE::NODE, 0, 0));
+	COLLADAFW::Node* vsNode2 = new COLLADAFW::Node(COLLADAFW::UniqueId(COLLADAFW::COLLADA_TYPE::NODE, 1, 0));
+	visualScene->getRootNodes().append(vsNode1);
+	visualScene->getRootNodes().append(vsNode2);
+
+	// Create 2 instance_nodes that refers to the same node that is under library_nodes
+	COLLADAFW::UniqueId instanceId1(COLLADAFW::COLLADA_TYPE::NODE, 2, 0);
+	COLLADAFW::InstanceNode *instance_libNode1_1 = new COLLADAFW::InstanceNode(COLLADAFW::UniqueId(COLLADAFW::COLLADA_TYPE::INSTANCE_NODE, 0, 0), instanceId1);
+	COLLADAFW::InstanceNode *instance_libNode1_2 = new COLLADAFW::InstanceNode(COLLADAFW::UniqueId(COLLADAFW::COLLADA_TYPE::INSTANCE_NODE, 1, 0), instanceId1);
+	vsNode1->getInstanceNodes().append(instance_libNode1_1);
+	vsNode2->getInstanceNodes().append(instance_libNode1_2);
+
+	// Create node under libary_node that is refered to by the 2 root nodes
+	COLLADAFW::Node* libNode1 = new COLLADAFW::Node(instanceId1);
+
+	// Create node under libary_node that is refered to by the previous node
+	COLLADAFW::UniqueId instanceId2(COLLADAFW::COLLADA_TYPE::NODE, 3, 0);
+	COLLADAFW::Node* libNode2 = new COLLADAFW::Node(instanceId2);
+
+	COLLADAFW::InstanceNode *instance_libNode2 = new COLLADAFW::InstanceNode(COLLADAFW::UniqueId(COLLADAFW::COLLADA_TYPE::INSTANCE_NODE, 2, 0), instanceId2);
+	libNode1->getInstanceNodes().append(instance_libNode2);
+
+	COLLADAFW::LibraryNodes* libraryNodes = new COLLADAFW::LibraryNodes();
+	libraryNodes->getNodes().append(libNode1);
+	libraryNodes->getNodes().append(libNode2);
+
+	this->writer->writeVisualScene(visualScene);
+	this->writer->writeLibraryNodes(libraryNodes);
+
+	GLTF::Scene* scene = this->asset->getDefaultScene();
+	ASSERT_TRUE(scene != NULL);
+
+	// We should have 2 root nodes
+	std::vector<GLTF::Node*> sceneNodes = scene->nodes;
+	ASSERT_EQ(sceneNodes.size(), 2);
+
+	// Each of these nodes should have 1 child (clones of libNode1)
+	ASSERT_EQ(sceneNodes[0]->children.size(), 1);
+	ASSERT_EQ(sceneNodes[1]->children.size(), 1);
+
+	// Each of those children should have 1 child (clones of libNode2)
+	ASSERT_EQ(sceneNodes[0]->children[0]->children.size(), 1);
+	ASSERT_EQ(sceneNodes[1]->children[0]->children.size(), 1);
+}


### PR DESCRIPTION
If you have a model that is laid out like this
```xml
    <library_visual_scenes>
        <visual_scene id="ID1">
            <node id="ID2a">
                <instance_node url="#ID3" />
            </node>
            <node id="ID2b">
                <instance_node url="#ID3" />
            </node>
        </visual_scene>
    </library_visual_scenes>
    <library_nodes>
        <node id="ID3">
            <node id="ID4">
                <node id="ID5">
                    <node id="ID6">
                        <node id="ID7" name="instance_1">
                            <instance_node url="#ID8" />
                        </node>
                    </node>
                </node>
            </node>
        </node>
        <node id="ID8">
        </node>
    </library_nodes>
```
`ID2a` and `ID2b` ends up as targets for `ID3`.

`ID3` is found and traversed and `ID7` ends up as the target for `ID8`

Then `ID3` is cloned twice and added as the child for `ID2a` and `ID2b`.

When `ID8` is found, its added as the child of the original `ID7`, but not the cloned versions of `ID7` that are part of the `ID2a` and `ID2b` subtrees.

I hope I explained that well enough. Essentially this PR allows you to pass a predicate to the `Node::clone` method that gets called on each node as we recursively clone the subtree. This allows us to update the mappings so that when an `instance_node` is resolved it updates all cloned parents with a copy of the resolved node.

I tried to make it generic by using the predicate instead of coupling `COLLADA2GLTFWriter` to the `GLTF::Node` class. It's a little hairy but I don't think its too bad.
