### PR TITLE
Fixes normal map segmentation fault

### DIFF
--- a/include/COLLADA2GLTFExtrasHandler.h
+++ b/include/COLLADA2GLTFExtrasHandler.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <set>
+#include <map>
 
 #include "GeneratedSaxParser.h"
 #include "COLLADASaxFWLLoader.h"
@@ -25,7 +26,7 @@ namespace COLLADA2GLTF {
 		bool _inDoubleSided = false;
 	public:
 		std::set<COLLADAFW::UniqueId> lockAmbientDiffuse;
-		COLLADAFW::TextureAttributes* bumpTexture = NULL;
+		std::map<COLLADAFW::UniqueId, COLLADAFW::TextureAttributes*> bumpTextures;
 		std::set<COLLADAFW::UniqueId> doubleSided;
 		ExtrasHandler(COLLADASaxFWL::Loader* loader) : _loader(loader) {};
 	};

--- a/src/COLLADA2GLTFExtrasHandler.cpp
+++ b/src/COLLADA2GLTFExtrasHandler.cpp
@@ -16,7 +16,8 @@ bool COLLADA2GLTF::ExtrasHandler::elementBegin(const COLLADASaxFWL::ParserChar* 
 		const COLLADASaxFWL::FileLoader* fileLoader = _loader->getFileLoader();
 		COLLADASaxFWL::LibraryEffectsLoader* effectsLoader = (COLLADASaxFWL::LibraryEffectsLoader*)fileLoader->getPartLoader();
 		COLLADAFW::Effect* bumpEffect = (COLLADAFW::Effect*)effectsLoader->getObject();
-		bumpTexture = bumpEffect->createExtraTextureAttributes();
+		COLLADAFW::TextureAttributes* bumpTexture = bumpEffect->createExtraTextureAttributes();
+		bumpTextures[_currentId] = bumpTexture;
 
 		size_t index = 0;
 		const GeneratedSaxParser::xmlChar* attributeKey = attributes[index++];

--- a/src/COLLADA2GLTFWriter.cpp
+++ b/src/COLLADA2GLTFWriter.cpp
@@ -1146,9 +1146,9 @@ bool COLLADA2GLTF::Writer::writeEffect(const COLLADAFW::Effect* effect) {
 			}
 		}
 
-		if (_extrasHandler->bumpTexture != NULL) {
-			material->values->bumpTexture = fromColladaTexture(effectCommon, _extrasHandler->bumpTexture->samplerId);
-			_extrasHandler->bumpTexture = NULL;
+		auto bumpTextureIt = _extrasHandler->bumpTextures.find(effect->getUniqueId());
+		if (bumpTextureIt != _extrasHandler->bumpTextures.end()) {
+			material->values->bumpTexture = fromColladaTexture(effectCommon, (*bumpTextureIt).second->samplerId);
 		}
 
 		bool doubleSided = _extrasHandler->doubleSided.find(effect->getUniqueId()) != _extrasHandler->doubleSided.end();


### PR DESCRIPTION
Fixes the segmentation fault for multiple materials and normal maps (see issue #249) 

- Using map of effect id to bump texture instead of only saving last bump
texture