### PR TITLE
Cache build directory in CI

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -34,11 +34,10 @@ jobs:
       env:
         cache-name: build-cache
       with:
-        path: ./build
-        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('CMakeLists.txt') }}
+        path: ${{ github.workspace }}/build
+        key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('CMakeLists.txt') }}
         restore-keys: |
-          ${{ runner.os }}-build-${{ env.cache-name }}-
-          ${{ runner.os }}-build-
+          ${{ runner.os }}-${{ env.cache-name }}-
           ${{ runner.os }}-
 
     - name: Add msbuild to PATH
@@ -47,7 +46,7 @@ jobs:
     - name: Run cmake
       run: |
         cd ${{ github.workspace }}
-        if not exist build mkdir build
+        mkdir build 2>NUL
         cd build
         cmake .. -Dtest=ON
 
@@ -122,11 +121,10 @@ jobs:
       env:
         cache-name: build-cache
       with:
-        path: ./build
-        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('CMakeLists.txt') }}
+        path: ${{ github.workspace }}/build
+        key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('CMakeLists.txt') }}
         restore-keys: |
-          ${{ runner.os }}-build-${{ env.cache-name }}-
-          ${{ runner.os }}-build-
+          ${{ runner.os }}-${{ env.cache-name }}-
           ${{ runner.os }}-
 
     - name: Run cmake
@@ -209,11 +207,10 @@ jobs:
       env:
         cache-name: build-cache
       with:
-        path: ./build
-        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('CMakeLists.txt') }}
+        path: ${{ github.workspace }}/build
+        key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('CMakeLists.txt') }}
         restore-keys: |
-          ${{ runner.os }}-build-${{ env.cache-name }}-
-          ${{ runner.os }}-build-
+          ${{ runner.os }}-${{ env.cache-name }}-
           ${{ runner.os }}-
 
     - name: Run cmake

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -5,7 +5,7 @@ jobs:
   cpplint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - uses: actions/setup-python@v1
     - run: pip install cpplint
     - run: cpplint --recursive .
@@ -25,9 +25,21 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
       with:
-          submodules: recursive
+        submodules: recursive
+
+    - name: Load Build Cache
+      uses: actions/cache@v2
+      env:
+        cache-name: build-cache
+      with:
+        path: ./build
+        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('CMakeLists.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-build-${{ env.cache-name }}-
+          ${{ runner.os }}-build-
+          ${{ runner.os }}-
 
     - name: Add msbuild to PATH
       uses: microsoft/setup-msbuild@v1.0.0
@@ -35,7 +47,7 @@ jobs:
     - name: Run cmake
       run: |
         cd ${{ github.workspace }}
-        mkdir build
+        mkdir -p build
         cd build
         cmake .. -Dtest=ON
 
@@ -101,9 +113,21 @@ jobs:
         node-version: 8
 
     - name: Checkout
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
       with:
           submodules: recursive
+
+    - name: Load Build Cache
+      uses: actions/cache@v2
+      env:
+        cache-name: build-cache
+      with:
+        path: ./build
+        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('CMakeLists.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-build-${{ env.cache-name }}-
+          ${{ runner.os }}-build-
+          ${{ runner.os }}-
 
     - name: Run cmake
       run: |
@@ -176,9 +200,21 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
       with:
           submodules: recursive
+
+    - name: Load Build Cache
+      uses: actions/cache@v2
+      env:
+        cache-name: build-cache
+      with:
+        path: ./build
+        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('CMakeLists.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-build-${{ env.cache-name }}-
+          ${{ runner.os }}-build-
+          ${{ runner.os }}-
 
     - name: Run cmake
       run: |

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -29,24 +29,22 @@ jobs:
       with:
         submodules: recursive
 
+    - name: Add msbuild to PATH
+      uses: microsoft/setup-msbuild@v1.0.0
+
     - name: Load Build Cache
+      id: cache
       uses: actions/cache@v2
       env:
         cache-name: build-cache
       with:
-        path: ${{ github.workspace }}/build
+        path: build
         key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('CMakeLists.txt') }}
-        restore-keys: |
-          ${{ runner.os }}-${{ env.cache-name }}-
-          ${{ runner.os }}-
-
-    - name: Add msbuild to PATH
-      uses: microsoft/setup-msbuild@v1.0.0
 
     - name: Run cmake
-      run: |
-        cd ${{ github.workspace }}
-        mkdir build /p
+      if: !steps.cache.outputs.cache-hit
+    - run: mkdir build
+    - run: |
         cd build
         cmake .. -Dtest=ON
 
@@ -117,20 +115,18 @@ jobs:
           submodules: recursive
 
     - name: Load Build Cache
+      id: cache
       uses: actions/cache@v2
       env:
         cache-name: build-cache
       with:
-        path: ${{ github.workspace }}/build
+        path: build
         key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('CMakeLists.txt') }}
-        restore-keys: |
-          ${{ runner.os }}-${{ env.cache-name }}-
-          ${{ runner.os }}-
 
     - name: Run cmake
-      run: |
-        cd ${{ github.workspace }}
-        mkdir -p build
+      if: !steps.cache.outputs.cache-hit
+    - run: mkdir build
+    - run: |
         cd build
         cmake .. -Dtest=ON
 
@@ -203,20 +199,18 @@ jobs:
           submodules: recursive
 
     - name: Load Build Cache
+      id: cache
       uses: actions/cache@v2
       env:
         cache-name: build-cache
       with:
-        path: ${{ github.workspace }}/build
+        path: build
         key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('CMakeLists.txt') }}
-        restore-keys: |
-          ${{ runner.os }}-${{ env.cache-name }}-
-          ${{ runner.os }}-
 
     - name: Run cmake
-      run: |
-        cd ${{ github.workspace }}
-        mkdir -p build
+      if: !steps.cache.outputs.cache-hit
+    - run: mkdir build
+    - run: |
         cd build
         cmake .. -Dtest=ON
 

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -47,7 +47,7 @@ jobs:
     - name: Run cmake
       run: |
         cd ${{ github.workspace }}
-        mkdir -p build
+        if not exist build mkdir build
         cd build
         cmake .. -Dtest=ON
 
@@ -132,7 +132,7 @@ jobs:
     - name: Run cmake
       run: |
         cd ${{ github.workspace }}
-        mkdir build
+        mkdir -p build
         cd build
         cmake .. -Dtest=ON
 
@@ -219,7 +219,7 @@ jobs:
     - name: Run cmake
       run: |
         cd ${{ github.workspace }}
-        mkdir build
+        mkdir -p build
         cd build
         cmake .. -Dtest=ON
 

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -42,9 +42,8 @@ jobs:
         key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('CMakeLists.txt') }}
 
     - name: Run cmake
-      if: !steps.cache.outputs.cache-hit
-    - run: mkdir build
-    - run: |
+      run: |
+        if [ ! ${{ format('{0}', steps.cache.outputs.cache-hit) }} ]; then mkdir build fi
         cd build
         cmake .. -Dtest=ON
 
@@ -124,9 +123,8 @@ jobs:
         key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('CMakeLists.txt') }}
 
     - name: Run cmake
-      if: !steps.cache.outputs.cache-hit
-    - run: mkdir build
-    - run: |
+      run: |
+        if [ ! ${{ format('{0}', steps.cache.outputs.cache-hit) }} ]; then mkdir build fi
         cd build
         cmake .. -Dtest=ON
 
@@ -208,9 +206,8 @@ jobs:
         key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('CMakeLists.txt') }}
 
     - name: Run cmake
-      if: !steps.cache.outputs.cache-hit
-    - run: mkdir build
-    - run: |
+      run: |
+        if [ ! ${{ format('{0}', steps.cache.outputs.cache-hit) }} ]; then mkdir build fi
         cd build
         cmake .. -Dtest=ON
 

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -46,7 +46,7 @@ jobs:
     - name: Run cmake
       run: |
         cd ${{ github.workspace }}
-        mkdir build 2>NUL
+        mkdir build /p
         cd build
         cmake .. -Dtest=ON
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@ Change Log
 ##### Additions :tada:
 * Switch CI builds to GitHub actions [#264](https://github.com/KhronosGroup/COLLADA2GLTF/pull/264)
 * Large-scale code cleanup and add cppcheck to CI to prevent backsliding [#265](https://github.com/KhronosGroup/COLLADA2GLTF/pull/265)
+* Speed up CI build times [#189](https://github.com/KhronosGroup/COLLADA2GLTF/issues/189)
 
 ##### Fixes :wrench:
 * De-duplicate GLTF generated materials [#251](https://github.com/KhronosGroup/COLLADA2GLTF/issues/251)


### PR DESCRIPTION
Fixes #189 

This may need some follow-up for invalidating the cache when updating submodules, but one thing at a time.