### PR TITLE
Fix for output paths with multiple extensions

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -169,8 +169,15 @@ int main(int argc, const char** argv) {
         outputPathDirURI.toNativePath(COLLADABU::Utils::getSystemType());
 
     if (options->binary && outputPathExtension != "glb") {
+      std::string glbExtension;
+      std::size_t dotIndex = outputPathExtension.rfind('.');
+      if (dotIndex == std::string::npos)
+        glbExtension = ".glb";
+      else
+        glbExtension = "." + outputPathExtension.substr(0, dotIndex) + ".glb";
+
       outputPathURI = COLLADABU::URI::nativePathToUri(
-          outputPathDir + outputPathBaseName + ".glb");
+          outputPathDir + outputPathBaseName + glbExtension);
       options->outputPath =
           outputPathURI.toNativePath(COLLADABU::Utils::getSystemType());
     }


### PR DESCRIPTION
Fixes #271

If the output file path has multiple file extensions and the binary flag is set, only the final extension will be replaced.

Running COLLADA2GLTF-bin with the following arguments will now result in these output files:
`COLLADA2GLTF-bin -i input_file.ext.dae -o output_file.ext.glb -b` -> `output_file.ext.glb`
`COLLADA2GLTF-bin -i input_file.ext.dae -o output_file.ext.xyz -b` -> `output_file.ext.glb`
`COLLADA2GLTF-bin -i input_file.ext.dae -o output_file.glb -b` -> `output_file.glb`
`COLLADA2GLTF-bin -i input_file.ext.dae -o output_file.xyz -b` -> `output_file.glb`