### PR TITLE
Fix incorrect delete operator in GLTFMaterial.cpp

### DIFF
--- a/GLTF/src/GLTFMaterial.cpp
+++ b/GLTF/src/GLTFMaterial.cpp
@@ -904,7 +904,7 @@ GLTF::MaterialPBR::~MaterialPBR() {
   delete normalTexture;
   delete occlusionTexture;
   delete emissiveTexture;
-  delete emissiveFactor;
+  delete[] emissiveFactor;
 }
 
 GLTF::MaterialPBR::MaterialPBR() {


### PR DESCRIPTION
Valgrind:
```
==86338== Mismatched free() / delete / delete []
==86338==    at 0x4C2B51D: operator delete(void*) (vg_replace_malloc.c:586)
==86338==    by 0x1092758: GLTF::MaterialPBR::~MaterialPBR() (GLTFMaterial.cpp:907)
==86338==    by 0x1092791: GLTF::MaterialPBR::~MaterialPBR() (GLTFMaterial.cpp:908)
==86338==    by 0x106A1E1: std::default_delete<GLTF::Material>::operator()(GLTF::Material*) const (unique_ptr.h:81)
==86338==    by 0x105F7FD: std::default_delete<GLTF::Material> std::for_each<__gnu_cxx::__normal_iterator<GLTF::Material**, std::vector<GLTF::Material*, std::allocator<GLTF::Material*> > >, std::default_delete<GLTF::Material> >(__gnu_cxx::__normal_iterator<GLTF::Material**, std::vector<GLTF::Material*, std::allocator<GLTF::Material*> > >, __gnu_cxx::__normal_iterator<GLTF::Material**, std::vector<GLTF::Material*, std::allocator<GLTF::Material*> > >, std::default_delete<GLTF::Material>) (stl_algo.h:3876)
==86338==    by 0x1058BB8: void GLTFObjectDeleter<GLTF::Material>(std::vector<GLTF::Material*, std::allocator<GLTF::Material*> >&&) (GLTFAsset.cpp:15)
==86338==    by 0x104B81B: GLTF::Asset::~Asset() (GLTFAsset.cpp:40)
==86338==    by 0x71230B: ColladaModel::ToGltf(CConversionOptions const&) const (ColladaModel.cpp:109)
==86338==    by 0x70E606: libmain(int, char const**) (ModelConverterMain.cpp:108)
==86338==    by 0x6B95ED: ModelConversionTest::RunTest(std::basic_string<wchar_t, std::char_traits<wchar_t>, std::allocator<wchar_t> > const&) (ModelConversionTests.cpp:181)
==86338==    by 0x6C1F32: (anonymous namespace)::ModelConversionTest_FailBadBinFile_Test::TestBody() (ModelConversionTests.cpp:1192)
==86338==    by 0x180AA6A: void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (gtest.cc:2417)
==86338==  Address 0x723df30 is 0 bytes inside a block of size 12 alloc'd
==86338==    at 0x4C2AC38: operator new[](unsigned long) (vg_replace_malloc.c:433)
==86338==    by 0x1092ACD: GLTF::MaterialCommon::getMaterialPBR(GLTF::Options*) (GLTFMaterial.cpp:945)
==86338==    by 0x10547EE: GLTF::Asset::writeJSON(void*, GLTF::Options*) (GLTFAsset.cpp:1467)
==86338==    by 0x711F88: ColladaModel::ToGltf(CConversionOptions const&) const (ColladaModel.cpp:243)
==86338==    by 0x70E606: libmain(int, char const**) (ModelConverterMain.cpp:108)
==86338==    by 0x6B95ED: ModelConversionTest::RunTest(std::basic_string<wchar_t, std::char_traits<wchar_t>, std::allocator<wchar_t> > const&) (ModelConversionTests.cpp:181)
==86338==    by 0x6C1F32: (anonymous namespace)::ModelConversionTest_FailBadBinFile_Test::TestBody() (ModelConversionTests.cpp:1192)
==86338==    by 0x180AA6A: void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (gtest.cc:2417)
==86338==    by 0x1805C4F: void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (gtest.cc:2453)
==86338==    by 0x17E8F0B: testing::Test::Run() (gtest.cc:2491)
==86338==    by 0x17E976F: testing::TestInfo::Run() (gtest.cc:2667)
==86338==    by 0x17E9DBC: testing::TestCase::Run() (gtest.cc:2785)
==86338== 
```